### PR TITLE
Remove S4 classes unconditionally when unloading

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # pkgload 0.0.0.9000
 
+* `unload()` now unloads S4 classes for packages loaded with `library()` as
+  well as `load_all()` (#46).
+
 * `load_all()` gains a `helpers` option to specify whether or not to
   source testthat helpers. (@pitakakariki devtools #1202)
 

--- a/R/remove-s4-class.r
+++ b/R/remove-s4-class.r
@@ -4,8 +4,12 @@
 # classes this way, and attempting to do so will result in errors.
 remove_s4_classes <- function(pkg = ".") {
   pkg <- as.package(pkg)
+  nsenv <- ns_env(pkg)
+  if (is.null(nsenv)) {
+    return()
+  }
 
-  classes <- methods::getClasses(ns_env(pkg))
+  classes <- methods::getClasses(nsenv)
   lapply(sort_s4classes(classes, pkg), remove_s4_class, pkg)
 }
 
@@ -99,10 +103,10 @@ remove_s4_class <- function(classname, pkg) {
   class@contains <- class@contains[keep_idx]
 
   # Assign the modified class back into the package
-  methods::assignClassDef(classname, class, where = nsenv)
+  methods::assignClassDef(classname, class, where = nsenv, force = TRUE)
 
-  # Remove the class.
-  methods::removeClass(classname, where = nsenv)
+  # Remove the class, ignoring failures due to potentially locked environments.
+  tryCatch(methods::removeClass(classname, where = nsenv), error = function(e) NULL)
 }
 
 

--- a/R/unload.r
+++ b/R/unload.r
@@ -53,11 +53,8 @@ unload <- function(pkg = ".", quiet = FALSE) {
     eapply(ns_env(pkg), force, all.names = TRUE)
   }
 
-  # If the package was loaded with devtools, any s4 classes that were created
-  # by the package need to be removed in a special way.
-  if (!is.null(dev_meta(pkg$package))) {
-    remove_s4_classes(pkg)
-  }
+  # S4 classes that were created by the package need to be removed in a special way.
+  remove_s4_classes(pkg)
 
 
   if (pkg$package %in% loadedNamespaces()) {

--- a/tests/testthat/test-s4-unload.r
+++ b/tests/testthat/test-s4-unload.r
@@ -22,45 +22,52 @@ get_subclasses <- function(class) {
 
 
 test_that("loading and reloading s4 classes", {
+  run_tests <- function() {
+    # Check class hierarchy
+    expect_equal(get_superclasses("A"), c("AB", "AOrNull", "mle2A", "mleA"))
+    expect_equal(get_subclasses("AB"), c("A", "B"))
+    expect_equal(get_superclasses("mle2"), c("mle", "mle2A", "mleA"))
+    expect_equal(get_subclasses("mleA"), c("A", "mle", "mle2"))
+    expect_equal(get_subclasses("mle2A"), c("A", "mle2"))
+    expect_equal(get_subclasses("AOrNull"), c(".NULL", "A", "NULL"))
+    expect_equal(get_subclasses("BOrNull"), c(".NULL", "B", "NULL"))
+
+    # Check that package is registered correctly
+    expect_equal(getClassDef("A")@package, "testS4union")
+    expect_equal(getClassDef("AB")@package, "testS4union")
+    expect_equal(getClassDef("mle2")@package, "testS4union")
+    expect_equal(getClassDef("AOrNull")@package, "testS4union")
+    expect_equal(getClassDef("BOrNull")@package, "testS4union")
+
+    # Unloading shouldn't result in any errors or warnings
+    expect_warning(unload("testS4union"), NA)
+
+    # Check that classes are unregistered
+    expect_true(is.null(getClassDef("A")))
+    expect_true(is.null(getClassDef("B")))
+    expect_true(is.null(getClassDef("AB")))
+    expect_true(is.null(getClassDef("AorNULL")))
+    expect_true(is.null(getClassDef("BorNULL")))
+  }
+
   load_all("testS4union")
-
-  # Check class hierarchy
-  expect_equal(get_superclasses("A"), c("AB", "mle2A", "mleA"))
-  expect_equal(get_subclasses("AB"), c("A", "B"))
-  expect_equal(get_superclasses("mle2"), c("mle", "mle2A", "mleA"))
-  expect_equal(get_subclasses("mleA"), c("A", "mle", "mle2"))
-  expect_equal(get_subclasses("mle2A"), c("A", "mle2"))
-
-  # Check that package is registered correctly
-  expect_equal(getClassDef("A")@package, "testS4union")
-  expect_equal(getClassDef("AB")@package, "testS4union")
-  expect_equal(getClassDef("mle2")@package, "testS4union")
-
-  # Unloading shouldn't result in any errors or warnings
-  expect_warning(unload("testS4union"), NA)
-
-  # Check that classes are unregistered
-  expect_true(is.null(getClassDef("A")))
-  expect_true(is.null(getClassDef("B")))
-  expect_true(is.null(getClassDef("AB")))
-
+  run_tests()
 
   # Load again and repeat tests --------------------------------------------
+  load_all("testS4union")
+
+  run_tests()
+
+  # Install package then load and run tests
+  withr::with_temp_libpaths({
+    install.packages("testS4union", repos = NULL, type = "source", quiet = TRUE)
+    library("testS4union")
+    load_all("testS4union")
+    run_tests()
+  })
 
   # Loading again shouldn't result in any errors or warnings
   expect_warning(load_all("testS4union", reset = FALSE), NA)
-
-  # Check class hierarchy
-  expect_equal(get_superclasses("A"), c("AB", "mle2A", "mleA"))
-  expect_equal(get_subclasses("AB"), c("A", "B"))
-  expect_equal(get_superclasses("mle2"), c("mle", "mle2A", "mleA"))
-  expect_equal(get_subclasses("mleA"), c("A", "mle", "mle2"))
-  expect_equal(get_subclasses("mle2A"), c("A", "mle2"))
-
-  # Check that package is registered correctly
-  expect_equal(getClassDef("A")@package, "testS4union")
-  expect_equal(getClassDef("AB")@package, "testS4union")
-  expect_equal(getClassDef("mle2")@package, "testS4union")
 
   unload("testS4union")
   unloadNamespace("stats4")   # This was imported by testS4union
@@ -68,7 +75,7 @@ test_that("loading and reloading s4 classes", {
   # Check that classes are unregistered
   # This test on A fails for some bizarre reason - bug in R? But it doesn't
   # to cause any practical problems.
-  # expect_true(is.null(getClassDef("A")))
+  expect_true(is.null(getClassDef("A")))
   expect_true(is.null(getClassDef("B")))
   expect_true(is.null(getClassDef("AB")))
 })

--- a/tests/testthat/testS4union/R/classes.r
+++ b/tests/testthat/testS4union/R/classes.r
@@ -6,3 +6,6 @@ setClassUnion("AB", members = c("A", "B"))
 setClass("mle2", contains = "mle")
 setClassUnion("mleA", members = c("mle", "A"))
 setClassUnion("mle2A", members = c("mle2", "A"))
+
+setClassUnion("AOrNull", members = c("A", "NULL"))
+setClassUnion("BOrNull", members = c("B", "NULL"))


### PR DESCRIPTION
Any S4 classes defined by a package need to always be removed when
unloaded, not just when they were originally loaded by `load_all()`.
This prevents errors when loading a package with `library()` or
`loadNamespace()` then trying to load it with `load_all()`, due to
having old class definitions in subclasses and class unions.

Fixes #46