### PR TITLE
Export package imports by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # pkgload 0.0.0.9000
 
+* Package imports are now exported when using `load_all()`. This behavior can
+  be disabled by using `load_all(export_imports = FALSE)`.
+
 * The `as.package()` and `is.package()` functions have been removed.
 
 * `load_code()`, `load_data()`, `load_dll()`, `load_all()`, `parse_ns_file()`

--- a/R/load.r
+++ b/R/load.r
@@ -68,6 +68,9 @@
 #' @param export_all If `TRUE` (the default), export all objects.
 #'   If `FALSE`, export only the objects that are listed as exports
 #'   in the NAMESPACE file.
+#' @param export_imports If `TRUE` (the default), export all objects that are
+#'   imported by the package. If `FALSE` export only objects defined in the
+#'   package.
 #' @param helpers if \code{TRUE} loads \pkg{testthat} test helpers.
 #' @param quiet if `TRUE` suppresses output from this function.
 #' @param recollate if `TRUE`, run [roxygen2::update_collate()] before loading.
@@ -89,7 +92,8 @@
 #' }
 #' @export
 load_all <- function(path = ".", reset = TRUE, recompile = FALSE,
-                     export_all = TRUE, helpers = TRUE, recollate = FALSE, quiet = FALSE) {
+                     export_all = TRUE, export_imports = export_all,
+                     helpers = TRUE, recollate = FALSE, quiet = FALSE) {
   path <- pkg_path(path)
   package <- pkg_name(path)
   description <- pkg_desc(path)
@@ -188,7 +192,7 @@ load_all <- function(path = ".", reset = TRUE, recompile = FALSE,
 
   # Set up the exports in the namespace metadata (this must happen after
   # the objects are loaded)
-  setup_ns_exports(path, export_all)
+  setup_ns_exports(path, export_all, export_imports)
 
   # Set up the package environment ------------------------------------
   # Create the package environment if needed

--- a/R/namespace-env.r
+++ b/R/namespace-env.r
@@ -80,7 +80,7 @@ setup_ns_imports <- function(path = ".") {
 # Read the NAMESPACE file and set up the exports metdata. This must be
 # run after all the objects are loaded into the namespace because
 # namespaceExport throw errors if the objects are not present.
-setup_ns_exports <- function(path = ".", export_all = FALSE) {
+setup_ns_exports <- function(path = ".", export_all = FALSE, export_imports = export_all) {
   path <- pkg_path(path)
   package <- pkg_name(path)
 
@@ -92,6 +92,11 @@ setup_ns_exports <- function(path = ".", export_all = FALSE) {
     # Make sure to re-export objects that are imported from other packages but
     # not copied.
     exports <- union(exports, nsInfo$exports)
+
+    # if export_imports export all imports as well
+    if (export_imports) {
+      exports <- c(exports, ls(imports_env(package), all.names = TRUE))
+    }
 
     # List of things to ignore is from loadNamespace. There are also a
     # couple things to ignore from devtools.

--- a/man/load_all.Rd
+++ b/man/load_all.Rd
@@ -5,7 +5,8 @@
 \title{Load complete package.}
 \usage{
 load_all(path = ".", reset = TRUE, recompile = FALSE, export_all = TRUE,
-  helpers = TRUE, recollate = FALSE, quiet = FALSE)
+  export_imports = export_all, helpers = TRUE, recollate = FALSE,
+  quiet = FALSE)
 }
 \arguments{
 \item{path}{Path to a package, or within a package.}
@@ -23,6 +24,10 @@ This is equivalent to running \code{\link[pkgbuild:clean_dll]{pkgbuild::clean_dl
 \item{export_all}{If \code{TRUE} (the default), export all objects.
 If \code{FALSE}, export only the objects that are listed as exports
 in the NAMESPACE file.}
+
+\item{export_imports}{If \code{TRUE} (the default), export all objects that are
+imported by the package. If \code{FALSE} export only objects defined in the
+package.}
 
 \item{helpers}{if \code{TRUE} loads \pkg{testthat} test helpers.}
 

--- a/tests/testthat/test-imports.r
+++ b/tests/testthat/test-imports.r
@@ -27,7 +27,7 @@ test_that("Imported objects are copied to package environment", {
 
 
 test_that("Imported objects are be re-exported", {
-  load_all("testNamespace")
+  load_all("testNamespace", export_imports = FALSE)
   # bitAnd is imported and re-exported
   expect_identical(bitAnd, bitops::bitAnd)
   # bitOr is imported but not re-exported
@@ -43,4 +43,11 @@ test_that("Imported objects are be re-exported", {
   unload("testNamespace")
   unload("compiler")
   unload("bitops")
+
+  # If exports_imports = TRUE all imports are exported
+  load_all("testNamespace", export_imports = TRUE)
+  expect_true(exists("bitOr", .GlobalEnv))
+
+  # This is from the import(compiler)
+  expect_true(exists("compile", .GlobalEnv))
 })


### PR DESCRIPTION
This behavior makes the environment when using load_all more closely
mimic the internal package environment, where imports objects can be
specified without qualifications.

Fixes #38