### PR TITLE
Emit and warning and return `FALSE` for missing dependencies

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # pkgload 0.0.0.9000
 
+* `check_dep_version()` now emits a warning and returns `FALSE` rather than
+  aborting. (#47)
+
 * Package imports are now exported when using `load_all()`. This behavior can
   be disabled by using `load_all(export_imports = FALSE)`.
 

--- a/R/imports-env.r
+++ b/R/imports-env.r
@@ -56,11 +56,21 @@ load_imports <- function(path = ".") {
   # process_imports()
   if (length(ls(imports_env(package))) > 0) return(invisible(imports))
 
-  mapply(check_dep_version, imports$package, imports$version)
+  res <- mapply(check_dep_version, imports$package, imports$version)
+  abort_for_missing_packages(res, imports$package)
 
   process_imports(path)
 
   invisible(deps)
+}
+
+abort_for_missing_packages <- function(x, pkgs) {
+  if (any(!x)) {
+    abort(
+      paste0("Dependency package(s) ",
+        paste0("'", pkgs[!x], "'", collapse = ","),
+        " not available."))
+  }
 }
 
 # Load imported objects

--- a/R/load-depends.r
+++ b/R/load-depends.r
@@ -9,7 +9,9 @@ load_depends <- function(path = ".") {
   depends <- deps[deps$type == "Depends" & deps$package != "R", ]
   if (length(depends) == 0) return(invisible())
 
-  mapply(check_dep_version, depends$package, depends$version)
+  res <- mapply(check_dep_version, depends$package, depends$version)
+  abort_for_missing_packages(res, imports$package)
+
   lapply(depends$package, require, character.only = TRUE)
 
   invisible(depends)

--- a/R/package-deps.r
+++ b/R/package-deps.r
@@ -57,7 +57,8 @@ check_dep_version <- function(dep_name, dep_ver = "*") {
   }
 
   if (!requireNamespace(dep_name, quietly = TRUE)) {
-    stop("Dependency package ", dep_name, " not available.")
+    warning("Dependency package ", dep_name, " not available.")
+    return(FALSE)
   }
   if (dep_ver == "*") {
     return(TRUE)

--- a/tests/testthat/test-depend.r
+++ b/tests/testthat/test-depend.r
@@ -12,7 +12,9 @@ test_that("Warned about dependency versions", {
 
 test_that("Error on missing dependencies", {
   # Should give a warning about missing package
-  expect_error(load_all("testImportMissing"), "missingpackage not available")
+  expect_error(regexp =  "Dependency package[(]s[)] 'missingpackage' not available",
+    expect_warning(regexp = "missingpackage not available",
+      load_all("testImportMissing")))
 
   # Loading process will be partially done; unload it
   unload("testImportMissing")


### PR DESCRIPTION
This makes the behavior more useful if there are multiple missing
dependencies for a package, as you can see all of them in the error
message.

Fixes #47