### PR TITLE
Assign .Depends to package environment to mimic more closely to library()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # pkgload 0.0.0.9000
 
-* `load_all()` now assigns `DESCRIPTION/Depends` to `.Depends` object of package environment. (@yiufung pkgload#61)
+* `load_all()` now assigns `DESCRIPTION/Depends` to `.Depends` object of 
+  package environment. (@yiufung pkgload#61)
 
 * `load_all()` now attaches `testthat` if the `attach_testthat` option is
   `TRUE`. This allows `load_all()` to more closely mimics the testing

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pkgload 0.0.0.9000
 
+* `load_all()` now assigns `DESCRIPTION/Depends` to `.Depends` object of package environment. (@yiufung pkgload#61)
+
 * `load_all()` now attaches `testthat` if the `attach_testthat` option is
   `TRUE`. This allows `load_all()` to more closely mimics the testing
   environment. (#56)

--- a/R/load.r
+++ b/R/load.r
@@ -208,6 +208,9 @@ load_all <- function(path = ".", reset = TRUE, recompile = FALSE,
   # Copy over objects from the namespace environment
   export_ns(package)
 
+  # Assign .Depends, if any, to package environment from namespace
+  assign_depends(package)
+
   # Run hooks
   run_pkg_hook(package, "attach")
   run_user_hook(package, "attach")

--- a/R/package-env.r
+++ b/R/package-env.r
@@ -45,6 +45,15 @@ export_ns <- function(package) {
   }
 }
 
+# Assign `.Depends` from namespace
+assign_depends <- function(package) {
+  pkgenv <- pkg_env(package)
+
+  desc <- pkg_desc(ns_path(package))
+  deps <- desc$get_deps()
+  depends <- unique(deps[deps$type == "Depends",]$package)
+  if (length(depends) > 0L) pkgenv$.Depends <- depends
+}
 
 #' Return package environment
 #'

--- a/R/package-env.r
+++ b/R/package-env.r
@@ -51,7 +51,8 @@ assign_depends <- function(package) {
 
   desc <- pkg_desc(ns_path(package))
   deps <- desc$get_deps()
-  depends <- unique(deps[deps$type == "Depends",]$package)
+  depends <- unique(deps[deps$type == "Depends"
+                         & deps$package != "R",]$package)
   if (length(depends) > 0L) pkgenv$.Depends <- depends
 }
 

--- a/tests/testthat/test-depend.r
+++ b/tests/testthat/test-depend.r
@@ -52,6 +52,6 @@ test_that("Parse dependencies", {
 test_that("Declared dependencies are added to .Depends object", {
   load_all("testDependsExists")
   expect_equal(get(".Depends", "package:testDependsExists", inherits = FALSE),
-                "data.table")
+                "httr")
   unload("testDependsExists")
 })

--- a/tests/testthat/test-depend.r
+++ b/tests/testthat/test-depend.r
@@ -48,3 +48,10 @@ test_that("Parse dependencies", {
   expect_equal(deps$compare, c("<", "=="))
   expect_equal(deps$version, c("2.1", "3.0.1"))
 })
+
+test_that("Declared dependencies are added to .Depends object", {
+  load_all("testDependsExists")
+  expect_equal(get(".Depends", "package:testDependsExists", inherits = FALSE),
+                "data.table")
+  unload("testDependsExists")
+})

--- a/tests/testthat/testDependsExists/DESCRIPTION
+++ b/tests/testthat/testDependsExists/DESCRIPTION
@@ -1,0 +1,8 @@
+Package: testDependsExists
+Title: Packages in Depends are assigned to .Depends object of package environment
+License: GPL-2
+Description:
+Author: Yiufung <cheongyiufung@gmail.com>
+Maintainer: Yiufung <cheongyiufung@gmail.com>
+Version: 0.1
+Depends: R, data.table

--- a/tests/testthat/testDependsExists/DESCRIPTION
+++ b/tests/testthat/testDependsExists/DESCRIPTION
@@ -5,4 +5,4 @@ Description:
 Author: Yiufung <cheongyiufung@gmail.com>
 Maintainer: Yiufung <cheongyiufung@gmail.com>
 Version: 0.1
-Depends: R, data.table
+Depends: R, httr


### PR DESCRIPTION
* Change introduced

In `load_all`, assign `.Depends` to package environment, following the behavior in R `attachNamespace()`, as shown in [R-3-4-3/src/library/base/R/namespace.R#L165](https://github.com/wch/r-source/blob/tags/R-3-4-3/src/library/base/R/namespace.R#L165). 



* Problems & Previous Workaround

It caused some issues that depend on this behavior, for example, using `data.table` within `test_that`. 

Previously, the workarounds are: 
1) add `.datatable.aware = TRUE` (or other code) to package source file to make it data.table-aware. This is because `data.table#cedta` check failed at [L32](https://github.com/Rdatatable/data.table/blob/f1d10c5fe9a1ac9111ab0e0d32cf014d6fe4075a/R/cedta.R#L32) and we had to assign manually to make [L37](https://github.com/Rdatatable/data.table/blob/f1d10c5fe9a1ac9111ab0e0d32cf014d6fe4075a/R/cedta.R#L37) work. See [data.table#2053](https://github.com/Rdatatable/data.table/issues/2053), [devtools#192](https://github.com/hadley/devtools/issues/192), [dplyr#548](https://github.com/tidyverse/dplyr/issues/548), 
2) manually change both DESCRIPTION/Imports **and** NAMESPACE. Not a preferred way as we all use roxygen2 to auto-generate NAMESPACE now, and to avoid that we had to add `#' @import data.table` directive in R code instead, which is no more convenient than 1). 

The pain point is that we cannot use data.table within our package during dev phase. @mattdowle proposed 2 ways at [answer](https://stackoverflow.com/questions/10527072/using-data-table-package-inside-my-own-package/10529888#10529888). The ii) way ( 2) above) works for dev phase, but it requires source code changed. The i) way works only after package development is finished and when user uses `library()` to attach the package, so it's not convenient during development. 

This commit enables: 
1) Only `DESCRIPTION/Depends` declaration is required, no R code change needed, keeping package source clean
2) Works during package development phase, so `devtools::test()` works
3) Mimicks even more closely to native `library()` behavior

* Reproducible example
As suggested by @hadley at [devtools#1472](https://github.com/hadley/devtools/issues/1472), a minimal package to reproduce the error is created at [skeleton_pkg](https://github.com/yiufung/skeleton-pkg):

![image](https://user-images.githubusercontent.com/1023375/34641714-5088f692-f343-11e7-897d-4eb3a2f56761.png)

With current `pkgload`:
![image](https://user-images.githubusercontent.com/1023375/34641653-384139b0-f342-11e7-8302-31c81f51c54c.png)

![image](https://user-images.githubusercontent.com/1023375/34641891-a01a718e-f345-11e7-85a7-ec81adfebac1.png)

With modified `pkgload`:
![image](https://user-images.githubusercontent.com/1023375/34641661-4d7d03a4-f342-11e7-9e0f-ea56c4ad36e5.png)

![image](https://user-images.githubusercontent.com/1023375/34642074-6418720a-f348-11e7-9bb4-bfa7b61a898d.png)



```
R version 3.4.3 (2017-11-30)
Platform: x86_64-w64-mingw32/x64 (64-bit)
Running under: Windows >= 8 x64 (build 9200)

Matrix products: default

locale:
[1] LC_COLLATE=Chinese (Traditional)_Hong Kong SAR.950  LC_CTYPE=Chinese (Traditional)_Hong Kong SAR.950   
[3] LC_MONETARY=Chinese (Traditional)_Hong Kong SAR.950 LC_NUMERIC=C                                       
[5] LC_TIME=Chinese (Traditional)_Hong Kong SAR.950    

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
[1] pkgload_0.0.0.9000

loaded via a namespace (and not attached):
 [1] compiler_3.4.3        backports_1.1.2       magrittr_1.5          assertthat_0.2.0      R6_2.2.2              rprojroot_1.3-2      
 [7] tools_3.4.3           withr_2.1.1           rstudioapi_0.7.0-9000 yaml_2.1.16           crayon_1.3.4          desc_1.1.1           
[13] testthat_2.0.0        rlang_0.1.6.9002     
```




  
  
  
  
  
  