### PR TITLE
Ensure environments and bindings are not locked on load_all()

### DIFF
--- a/R/namespace-env.r
+++ b/R/namespace-env.r
@@ -132,6 +132,7 @@ setup_ns_exports <- function(path = ".", export_all = FALSE, export_imports = ex
   # Update the exports metadata for the namespace with base::namespaceExport
   # It will throw warnings if objects are already listed in the exports
   # metadata, so catch those warnings and ignore them.
+  unlock_environment(nsenv)
   suppressWarnings(namespaceExport(nsenv, exports))
 
   invisible()

--- a/R/package-env.r
+++ b/R/package-env.r
@@ -24,6 +24,12 @@ run_ns_load_actions <- function(package) {
     action(nsenv)
 }
 
+maybe_unlock <- function(x, env) {
+  if (exists(x, envir = env, inherits = FALSE)) {
+    unlockBinding(x, env)
+  }
+}
+
 # Copy over the objects from the namespace env to the package env
 export_ns <- function(package) {
   nsenv <- ns_env(package)
@@ -31,7 +37,10 @@ export_ns <- function(package) {
   ns_path <- ns_path(nsenv)
   nsInfo <- parse_ns_file(ns_path)
 
+  unlock_environment(pkgenv)
   exports <- getNamespaceExports(nsenv)
+  lapply(exports, maybe_unlock, env = pkgenv)
+
   importIntoEnv(pkgenv, exports, nsenv, exports)
 
   desc <- pkg_desc(ns_path(package))


### PR DESCRIPTION
I'm not sure what's going on but `load_all()` is failing with the vdiffr package. This patch fixes it, hopefully it makes sense.