### PR TITLE
load_all(compile = FALSE) proceeds if the DLL doesn't exist yet

### DIFF
--- a/R/load-dll.r
+++ b/R/load-dll.r
@@ -32,7 +32,7 @@ onload_assign("load_dll", {
     dynLibs <- nsInfo$dynlibs
     nativeRoutines <- list()
 
-    !! for_loop
+    !!for_loop
     addNamespaceDynLibs(env, nsInfo$dynlibs)
 
     invisible(dlls)
@@ -94,3 +94,13 @@ onload_assign("assignNativeRoutines", {
       quote(package <- methods::getPackageName(env))))
   f
 })
+
+try_load_dll <- function(path = ".") {
+  tryCatch(
+    load_dll(path = path),
+    error = function(e) {
+      warn(paste0("Failed to load at least one DLL: ", e$message))
+      list()
+    }
+  )
+}

--- a/R/load.r
+++ b/R/load.r
@@ -189,7 +189,11 @@ load_all <- function(path = ".", reset = TRUE, compile = NA,
 
   out$code <- load_code(path)
   register_s3(path)
-  out$dll <- load_dll(path)
+  if (identical(compile, FALSE)) {
+    out$dll <- try_load_dll(path)
+  } else {
+    out$dll <- load_dll(path)
+  }
 
   # attach testthat to the search path
   if (isTRUE(attach_testthat) && package != "testthat") {


### PR DESCRIPTION
This allows `load_all()` to proceed with a warning if `compile = FALSE`. Useful in scenarios where we don't want to compile the DLL and also don't need it:

Closes https://github.com/klutometis/roxygen/issues/822.

Closes #82.

Rationale: `compile = FALSE` can create an inconsistent state in general, this is just another corner case.