### PR TITLE
Added shim_library.dynam function that loads compiled dll/so from ins…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # pkgload (development version)
 
+* Changed how compiled objects are loaded so that both the standard
+  location and, if that fails, the same relative path from within the
+  inst/ subdirectory are checked for compiled objects. This allows
+  packages with precompiled .so or .dll files within inst to be loaded
+  with `load_all` (@ethanplunkett, #48).
+
 * The `system.file()` shim now fails if you supply a path that starts
   with `inst` to better reproduce the behaviour with installed
   packages (#104).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,7 @@
 # pkgload (development version)
 
-* Changed how compiled objects are loaded so that both the standard
-  location and, if that fails, the same relative path from within the
-  inst/ subdirectory are checked for compiled objects. This allows
-  packages with precompiled .so or .dll files within inst to be loaded
-  with `load_all` (@ethanplunkett, #48).
+* Added support for loading a .so or .dll file from the `inst`
+  folder via a new `library.dynam()` shim (@ethanplunkett, #48).
 
 * The `system.file()` shim now fails if you supply a path that starts
   with `inst` to better reproduce the behaviour with installed

--- a/R/load-code.r
+++ b/R/load-code.r
@@ -6,7 +6,9 @@
 #' @inheritParams load_all
 #' @keywords programming
 #' @export
-load_code <- function(path = ".") {
+load_code <- function(path = ".", quiet = FALSE) {
+  quiet <- load_all_quiet(quiet, "load_code")
+
   path <- pkg_path(path)
   package <- pkg_name(path)
   encoding <- pkg_desc(path)$get("Encoding")
@@ -18,7 +20,7 @@ load_code <- function(path = ".") {
 
   env <- ns_env(package)
 
-  r_files <- find_code(path)
+  r_files <- find_code(path, quiet = quiet)
   paths <- changed_files(r_files)
   if (length(paths) == 0L) return()
 
@@ -37,7 +39,7 @@ load_code <- function(path = ".") {
 }
 
 # Find all R files in given directory.
-find_code <- function(path = ".") {
+find_code <- function(path = ".", quiet = FALSE) {
   path_r <- package_file("R", path = path)
 
   r_files <- withr_with_collate(
@@ -54,13 +56,13 @@ find_code <- function(path = ".") {
     collate <- file.path(path_r, collate)
 
     missing <- setdiff(collate, r_files)
-    if (length(missing) > 0) {
+    if (!quiet && length(missing) > 0) {
       cli::cli_alert_warning("Skipping missing files: {.file {missing}}")
     }
     collate <- setdiff(collate, missing)
 
     extra <- setdiff(r_files, collate)
-    if (length(extra) > 0) {
+    if (!quiet && length(extra) > 0) {
       cli::cli_alert_warning("Adding files missing in collate: {.file {extra}}")
     }
 

--- a/R/load.r
+++ b/R/load.r
@@ -122,8 +122,7 @@ load_all <- function(path = ".",
   description <- pkg_desc(path)
 
   withr::local_envvar(c(DEVTOOLS_LOAD = package))
-
-  quiet <- quiet %||% peek_option("testthat:::load_all_quiet") %||% FALSE
+  quiet <- load_all_quiet(quiet, "load_all")
 
   if (!quiet) {
     cli::cli_alert_info("Loading {.pkg {package}}")
@@ -194,7 +193,7 @@ load_all <- function(path = ".",
 
   out$data <- load_data(path)
 
-  out$code <- load_code(path)
+  out$code <- load_code(path, quiet = quiet)
   register_s3(path)
   if (identical(compile, FALSE)) {
     out$dll <- try_load_dll(path)
@@ -259,6 +258,13 @@ load_all <- function(path = ".",
   }
 
   invisible(out)
+}
+
+load_all_quiet <- function(quiet, fn = NULL) {
+  if (!is_null(fn)) {
+    quiet <- peek_option(sprintf("testthat:::%s_quiet_override", fn))
+  }
+  quiet %||% peek_option("testthat:::load_all_quiet") %||% FALSE
 }
 
 is_function_in_environment <- function(name, env) {

--- a/R/shims.r
+++ b/R/shims.r
@@ -5,6 +5,7 @@ insert_imports_shims <- function(package) {
   imp_env <- imports_env(package)
   imp_env$system.file <- shim_system.file
   imp_env$library.dynam.unload <- shim_library.dynam.unload
+  imp_env$library.dynam <- shim_library.dynam
 }
 
 # Create a new environment as the parent of global, with devtools versions of
@@ -127,3 +128,103 @@ shim_library.dynam.unload <- function(chname, libpath,
   # trying to unload a different package's DLL.
   base::library.dynam.unload(chname, libpath, verbose, file.ext)
 }
+
+shim_library.dynam <- function(chname, package, lib.loc,
+                               verbose = getOption("verbose"),
+                               file.ext = .Platform$dynlib.ext, ...){
+  # This shim version of library.dynam addresses the issue raised in:
+  #   https://github.com/r-lib/pkgload/issues/48
+  # Specifically that load_all() fails to find libraries placed within inst/libs/
+  # This CRAN incompatible practice allows for including a dll compiled
+  #  elsewhere in an R package.  See also: https://stackoverflow.com/questions/8977346
+
+  # This shim function first attempts using base::libary.dynam() if that fails
+  # it uses  .inst_libary.dynam()  which is very similar but insearts "inst/"
+  # in the dll/so  path.  Finally, if both of those fail it goes back
+  # to  the base::library.dynam() so that the error state is based on that
+  # function.
+
+  a <- tryCatch(base::library.dynam(chname, package, lib.loc,
+                                    verbose = getOption("verbose"),
+                                    file.ext = .Platform$dynlib.ext, ...),
+                error = function(e) e)
+  if(inherits(a, "error")){
+    # Call version of library.dynam that adds the inst subdirectory to
+    # the dll paths
+    b <- inst_library.dynam(chname, package, lib.loc,
+                             verbose = getOption("verbose"),
+                             file.ext = .Platform$dynlib.ext, ...)
+
+    # If both attempts fail go back to base::library:dynam so error
+    # state and debugging are based on that function
+    if(inherits(b, "error"))
+      base::library.dynam(chname, package, lib.loc,
+                          verbose = getOption("verbose"),
+                          file.ext = .Platform$dynlib.ext, ...)
+
+  }
+}
+
+
+
+inst_library.dynam <- function (chname, package, lib.loc,
+                                 verbose = getOption("verbose"),
+                                 file.ext = .Platform$dynlib.ext, ...){
+  # Version of libary.dynam that looks for libraries or objects to load
+  # Within the "/inst" package subdirectory. This is for the rare case that
+  # a user has placed a linked library or shared object compiled elsewhere
+  # within the inst/.
+  # Note this was copied from base::library.dynam v3.4.4
+  # Two lines were edited by replacing "libs" with "inst/libs"
+  # Otherwise it is unchanged.
+
+  dll_list <- .dynLibs()
+  if (missing(chname) || !nzchar(chname))
+    return(dll_list)
+  package
+  lib.loc
+  r_arch <- .Platform$r_arch
+  chname1 <- paste0(chname, file.ext)
+  for (pkg in find.package(package, lib.loc, verbose = verbose)) {
+    DLLpath <- if (nzchar(r_arch))
+      file.path(pkg, "inst/libs", r_arch)  # This line differs from base::dynam.load
+    else file.path(pkg, "inst/libs")       # This line differs from base::dynam.load
+    file <- file.path(DLLpath, chname1)
+    if (file.exists(file))
+      break
+    else file <- ""
+  }
+  if (file == "")
+    if (.Platform$OS.type == "windows")
+      stop(gettextf("DLL %s not found: maybe not installed for this architecture?",
+                    sQuote(chname)), domain = NA)
+  else stop(gettextf("shared object %s not found", sQuote(chname1)),
+            domain = NA)
+  file <- file.path(normalizePath(DLLpath, "/", TRUE), chname1)
+  ind <- vapply(dll_list, function(x) x[["path"]] == file,
+                NA)
+  if (length(ind) && any(ind)) {
+    if (verbose)
+      if (.Platform$OS.type == "windows")
+        message(gettextf("DLL %s already loaded", sQuote(chname1)),
+                domain = NA)
+    else message(gettextf("shared object '%s' already loaded",
+                          sQuote(chname1)), domain = NA)
+    return(invisible(dll_list[[seq_along(dll_list)[ind]]]))
+  }
+  if (.Platform$OS.type == "windows") {
+    PATH <- Sys.getenv("PATH")
+    Sys.setenv(PATH = paste(gsub("/", "\\\\", DLLpath),
+                            PATH, sep = ";"))
+    on.exit(Sys.setenv(PATH = PATH))
+  }
+  if (verbose)
+    message(gettextf("now dyn.load(\"%s\") ...", file),
+            domain = NA)
+  dll <- if ("DLLpath" %in% names(list(...)))
+    dyn.load(file, ...)
+  else dyn.load(file, DLLpath = DLLpath, ...)
+  .dynLibs(c(dll_list, list(dll)))
+  invisible(dll)
+}
+

--- a/R/utils.R
+++ b/R/utils.R
@@ -124,6 +124,7 @@ modify_lang <- function(x, f, ...) {
   } else if (is.function(x)) {
      formals(x) <- modify_lang(formals(x), f, ...)
      body(x) <- modify_lang(body(x), f, ...)
+     x
   } else {
     x
   }

--- a/man/load_code.Rd
+++ b/man/load_code.Rd
@@ -4,10 +4,12 @@
 \alias{load_code}
 \title{Load R code.}
 \usage{
-load_code(path = ".")
+load_code(path = ".", quiet = FALSE)
 }
 \arguments{
 \item{path}{Path to a package, or within a package.}
+
+\item{quiet}{if \code{TRUE} suppresses output from this function.}
 }
 \description{
 Load all R code in the \code{R} directory. The first time the code is

--- a/tests/testthat/test-load-collate.r
+++ b/tests/testthat/test-load-collate.r
@@ -9,7 +9,10 @@ test_that("If collate absent, load in alphabetical order", {
 })
 
 test_that("Warned about files missing from collate, but they're still loaded", {
-  expect_message(load_all("testCollateMissing"), "a.r")
+  with_options(
+    "testthat:::load_code_quiet_override" = FALSE,
+    expect_message(load_all("testCollateMissing"), "a.r")
+  )
 
   expect_equal(a, 1)
   expect_equal(b, 2)
@@ -18,7 +21,10 @@ test_that("Warned about files missing from collate, but they're still loaded", {
 })
 
 test_that("Extra files in collate don't error, but warn", {
-  expect_message(load_all("testCollateExtra"), "b.r")
+  with_options(
+    "testthat:::load_code_quiet_override" = FALSE,
+    expect_message(load_all("testCollateExtra"), "b.r")
+  )
 
   expect_equal(a, 1)
 

--- a/tests/testthat/test-shim.r
+++ b/tests/testthat/test-shim.r
@@ -159,7 +159,7 @@ test_that("shim_library.dynam loads compiled dll/so from inst/src/", {
   # Install testDllLoad package
   install.packages(test_path("testDllLoad"), repos = NULL, type = "source",
                    INSTALL_opts = "--no-multiarch", quiet = TRUE)
-  expect_true(require(testDllLoad))
+  expect_true(rlang::is_installed("testDllLoad"))
   unload("testDllLoad")
 
   # Copy  libs/ from installed testDllLoad packageinto  testDynLib/inst/libs/
@@ -169,7 +169,7 @@ test_that("shim_library.dynam loads compiled dll/so from inst/src/", {
   file.copy(compiled_libs, inst_dir, recursive = TRUE, overwrite = TRUE)
 
   load_all(pkg_dir)
-  expect_true(require(testLibDynam))
+  expect_true(rlang::is_installed("testLibDynam"))
 
   # Check that it's loaded properly, by running a function from the package.
   # nulltest3() calls a C function which returns null.

--- a/tests/testthat/test-shim.r
+++ b/tests/testthat/test-shim.r
@@ -142,12 +142,13 @@ test_that("shim_library.dynam loads compiled dll/so from inst/src/", {
   # 4. test that we can use load_all on the package and that the dll can be used
 
   # Make a temp lib directory to install test package into
-  old_libpaths <- .libPaths()
   tmp_libpath = file.path(tempdir(), "library-dynam-test")
-  if (!dir.exists(tmp_libpath)) dir.create(tmp_libpath)
-  .libPaths(c(tmp_libpath, .libPaths()))
+  if (!dir.exists(tmp_libpath)) {
+    dir.create(tmp_libpath)
+  }
 
-  # Reset the libpath on exit
+  old_libpaths <- .libPaths()
+  .libPaths(c(tmp_libpath, .libPaths()))
   on.exit(.libPaths(old_libpaths), add = TRUE)
 
   # Create temp directory for assembling testLibDynam with dll or so in inst/libs/
@@ -157,8 +158,13 @@ test_that("shim_library.dynam loads compiled dll/so from inst/src/", {
   expect_true(file.exists(pkg_dir))
 
   # Install testDllLoad package
-  install.packages(test_path("testDllLoad"), repos = NULL, type = "source",
-                   INSTALL_opts = "--no-multiarch", quiet = TRUE)
+  install.packages(
+    test_path("testDllLoad"),
+    repos = NULL,
+    type = "source",
+    INSTALL_opts = "--no-multiarch",
+    quiet = TRUE
+  )
   expect_true(rlang::is_installed("testDllLoad"))
   unload("testDllLoad")
 

--- a/tests/testthat/test-shim.r
+++ b/tests/testthat/test-shim.r
@@ -130,6 +130,8 @@ test_that("system.file() fails if path starts with `inst` (#104)", {
 })
 
 test_that("shim_library.dynam loads compiled dll/so from inst/src/", {
+  skip_on_cran()
+
   # Most of the code below is overhead to create a package that contains
   # a compiled .dll (or .so) within  inst/libs/
   # The process:

--- a/tests/testthat/test-shim.r
+++ b/tests/testthat/test-shim.r
@@ -168,7 +168,7 @@ test_that("shim_library.dynam loads compiled dll/so from inst/src/", {
   dir.create(file.path(inst_dir, "libs"), recursive = TRUE, showWarnings = FALSE)
   file.copy(compiled_libs, inst_dir, recursive = TRUE, overwrite = TRUE)
 
-  load_all(pkg_dir)
+  load_all(pkg_dir, quiet = TRUE)
   expect_true(rlang::is_installed("testLibDynam"))
 
   # Check that it's loaded properly, by running a function from the package.

--- a/tests/testthat/test-shim.r
+++ b/tests/testthat/test-shim.r
@@ -166,6 +166,8 @@ test_that("shim_library.dynam loads compiled dll/so from inst/src/", {
     quiet = TRUE
   )
   expect_true(rlang::is_installed("testDllLoad"))
+
+  pkgbuild::clean_dll("testDllLoad")
   unload("testDllLoad")
 
   # Copy  libs/ from installed testDllLoad packageinto  testDynLib/inst/libs/
@@ -183,7 +185,6 @@ test_that("shim_library.dynam loads compiled dll/so from inst/src/", {
 
   # Clean out compiled objects
   pkgbuild::clean_dll("testLibDynam")
-
   unload("testLibDynam")
 
   # Unlink temporary package dir

--- a/tests/testthat/test-shim.r
+++ b/tests/testthat/test-shim.r
@@ -128,3 +128,56 @@ test_that("system.file() fails if path starts with `inst` (#104)", {
     (expect_error(shim_system.file("inst", "WORDLIST", package = "pkgload", mustWork = TRUE)))
   })
 })
+
+test_that("shim_library.dynam loads compiled dll/so from inst/src/", {
+  # Most of the code below is overhead to create a package that contains
+  # a compiled .dll (or .so) within  inst/libs/
+  # The process:
+  # 1. Install the testDllLoad test package (we are going to use its .dll)
+  # 2. Copy the testLibDynam package to a temporary directory
+  # 3. Copy the contents of the libs/ directory from the installed testDllLoad
+  #   package into the temporary testLibDynam/inst/libs
+  # 4. test that we can use load_all on the package and that the dll can be used
+
+  # Make a temp lib directory to install test package into
+  old_libpaths <- .libPaths()
+  tmp_libpath = file.path(tempdir(), "library-dynam-test")
+  if (!dir.exists(tmp_libpath)) dir.create(tmp_libpath)
+  .libPaths(c(tmp_libpath, .libPaths()))
+
+  # Reset the libpath on exit
+  on.exit(.libPaths(old_libpaths), add = TRUE)
+
+  # Create temp directory for assembling testLibDynam with dll or so in inst/libs/
+  temp_dir <-tempdir()
+  file.copy(test_path("testLibDynam"), temp_dir, recursive = TRUE)
+  pkg_dir <- file.path(temp_dir, "testLibDynam")
+  expect_true(file.exists(pkg_dir))
+
+  # Install testDllLoad package
+  install.packages(test_path("testDllLoad"), repos = NULL, type = "source",
+                   INSTALL_opts = "--no-multiarch", quiet = TRUE)
+  expect_true(require(testDllLoad))
+  unload("testDllLoad")
+
+  # Copy  libs/ from installed testDllLoad packageinto  testDynLib/inst/libs/
+  inst_dir <-file.path(pkg_dir, "inst")
+  compiled_libs <- file.path(tmp_libpath, "testDllLoad", "libs")
+  dir.create(file.path(inst_dir, "libs"), recursive = TRUE, showWarnings = FALSE)
+  file.copy(compiled_libs, inst_dir, recursive = TRUE, overwrite = TRUE)
+
+  load_all(pkg_dir)
+  expect_true(require(testLibDynam))
+
+  # Check that it's loaded properly, by running a function from the package.
+  # nulltest3() calls a C function which returns null.
+  expect_true(is.null(nulltest3()))
+
+  # Clean out compiled objects
+  pkgbuild::clean_dll("testLibDynam")
+
+  unload("testLibDynam")
+
+  # Unlink temporary package dir
+  unlink(pkg_dir, recursive = TRUE)
+})

--- a/tests/testthat/testLibDynam/DESCRIPTION
+++ b/tests/testthat/testLibDynam/DESCRIPTION
@@ -1,0 +1,8 @@
+Package: testLibDynam
+Title: Test package for loading precompiled DLL/SO placed within inst/libs/ 
+License: GPL-2
+Description:
+Author: Hadley <h.wickham@gmail.com>
+Maintainer: Hadley <h.wickham@gmail.com>
+Version: 0.1
+Collate: a.r

--- a/tests/testthat/testLibDynam/NAMESPACE
+++ b/tests/testthat/testLibDynam/NAMESPACE
@@ -1,0 +1,2 @@
+export(nulltest3)
+export(nulltest4)

--- a/tests/testthat/testLibDynam/R/a.r
+++ b/tests/testthat/testLibDynam/R/a.r
@@ -1,0 +1,9 @@
+a <- 1
+
+nulltest3 <- function() {
+  .Call("null_test", PACKAGE = "testDllLoad")
+}
+
+nulltest4 <- function() {
+  .Call(null_test2)
+}

--- a/tests/testthat/testLibDynam/R/zzz.R
+++ b/tests/testthat/testLibDynam/R/zzz.R
@@ -1,0 +1,4 @@
+.onLoad <- function(lib, pkg){
+  library.dynam("testDllLoad", pkg, lib)
+
+}


### PR DESCRIPTION
I've added a shim version of library.dynam() to address the issue raised in https://github.com/r-lib/pkgload/issues/48, specifically that load_all() fails with a non-standard package that has compiled dll/so's within inst/libs/.  
