### PR TITLE
Make load_all work with explicitly qualified names in test helpers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # pkgload 1.0.1.9000
 
+* `load_all()` now allows using explicitly qualified, exported names in test
+  helpers (@klmr, #95).
+
 * `load_all()` gains a `compile` argument which controls more finely whether to
   compile the code or not. The `recompile` argument is now deprecated and will
   be removed in a future version of pkgload.

--- a/R/load.r
+++ b/R/load.r
@@ -208,13 +208,6 @@ load_all <- function(path = ".", reset = TRUE, compile = NA,
   # Copy over lazy data objects from the namespace environment
   export_lazydata(package)
 
-  # Source test helpers into package environment
-  if (uses_testthat(path) && helpers) {
-    withr_with_envvar(c(NOT_CRAN = "true", DEVTOOLS_LOAD = "true"),
-      testthat_source_test_helpers(find_test_dir(path), env = ns_env(package))
-    )
-  }
-
   # Set up the exports in the namespace metadata (this must happen after
   # the objects are loaded)
   setup_ns_exports(path, export_all, export_imports)
@@ -228,6 +221,13 @@ load_all <- function(path = ".", reset = TRUE, compile = NA,
   # Run hooks
   run_pkg_hook(package, "attach")
   run_user_hook(package, "attach")
+
+  # Source test helpers into package environment
+  if (uses_testthat(path) && helpers) {
+    withr_with_envvar(c(NOT_CRAN = "true", DEVTOOLS_LOAD = "true"),
+      testthat_source_test_helpers(find_test_dir(path), env = pkg_env(package))
+    )
+  }
 
   # Replace help and ? in utils package environment
   insert_global_shims()

--- a/tests/testthat/test-load.r
+++ b/tests/testthat/test-load.r
@@ -17,5 +17,8 @@ test_that("helpers are available after load_all", {
   # object definde in helper, referencing lazy data object mtcars2
   expect_equal(head_mtcars, head(mtcars2))
 
+  # object defined in helper using explicitly qualified package name
+  expect_equal(helper_baz, baz)
+
   unload("testLoadHelpers")
 })

--- a/tests/testthat/testLoadHelpers/tests/testthat/helpers.R
+++ b/tests/testthat/testLoadHelpers/tests/testthat/helpers.R
@@ -1,3 +1,5 @@
 foo <- 1
 
 head_mtcars <- head(mtcars2)
+
+helper_baz <- testLoadHelpers::baz


### PR DESCRIPTION
This fixes a regression in `devtools::load_all`: when using a fully qualified reference to an exported name of the package, like so,

https://github.com/r-lib/pkgload/blob/b3d93ff095a259c7dbda4a54f3665043942e0f16/tests/testthat/testLoadHelpers/tests/testthat/helpers.R#L5

`devtools::load_all` (and `pkgload::load_all`) fails with the error

> 'baz' is not an exported object from 'namespace:testLoadHelpers'

This commit adds a test case (which acts as a reprex) for the behaviour, as well as a fix.