### PR TITLE
Version com

### DIFF
--- a/R/package-deps.r
+++ b/R/package-deps.r
@@ -76,7 +76,10 @@ check_dep_version <- function(dep_name, dep_ver = "*") {
 
     warning("Need ", dep_name, " ", dep_compare,
       " ", dep_ver,
-      " but loaded version is ", getNamespaceVersion(dep_name))
+      " but loaded version is ", getNamespaceVersion(dep_name),
+      call. = FALSE
+    )
+
   }
 
   return(TRUE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -42,7 +42,7 @@ check_suggested <- function(package, version = NULL, compare = NA, path = inst("
 
   if (!is_installed(package) || !check_dep_version(package, version)) {
     msg <- paste0(sQuote(package),
-      if (is.na(version)) "" else paste0(" >= ", version),
+      if (is.na(version)) "" else paste0(" ", version),
       " must be installed for this functionality.")
 
     if (interactive()) {


### PR DESCRIPTION
```
> devtools:::check_suggested("abc", "> 3")
‘abc’ >= > 3 must be installed for this functionality.
Would you like to install it?

1: Yes
2: No
```

But needs a documentation fix too, I think. And probably a unit test.