### PR TITLE
Follow up CRAN and bump dev version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgload
 Title: Simulate Package Installation and Attach
-Version: 1.0.1.9000
+Version: 1.0.2
 Authors@R: c(
     person("Hadley", "Wickham", role = "aut"),
     person("Jim", "Hester", , "james.hester@rstudio.com", role = c("aut", "cre")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgload
 Title: Simulate Package Installation and Attach
-Version: 1.0.2
+Version: 1.0.2.9000
 Authors@R: c(
     person("Hadley", "Wickham", role = "aut"),
     person("Jim", "Hester", , "james.hester@rstudio.com", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# pkgload 1.0.1.9000
+# pkgload (development version)
+
+# pkgload 1.0.2
 
 * `shim_question()` now works for topics from the R base package that are passed with the double colon operator (e.g. `base::min`) (@mdequeljoe, #99).
 


### PR DESCRIPTION
This PR corresponds to the [latest CRAN version](https://cran.r-project.org/web/packages/pkgload/index.html).

The version registered with CRAN last year is `1.0.2`.
However, the GitHub development version DESCRIPTION specifies a smaller version.

So installing the package via GitHub will cause problems depending on the version of the `devtools` (*version 2.1.0 requires `pkgload` (> = 1.0.2)*).

```r
install.packages("devtools", repos = "https://cran.rstudio.com/") # 2.1.0
remotes::install_github("r-lib/pkgload") # 1.0.1.9000

devtools::check()
# Error in loadNamespace(j <- i[[1L]], c(lib.loc, .libPaths()), versionCheck = vI[[j]]) : 
#   namespace ‘pkgload’ 1.0.1.9000 is being loaded, but >= 1.0.2 is required
```

https://github.com/r-lib/devtools/blob/bf02cdaf86f0f8503745ef029a973233f9be7cff/DESCRIPTION#L28
