### PR TITLE
Minor fix for run_examples documentation.

### DIFF
--- a/R/dev-example.r
+++ b/R/dev-example.r
@@ -30,7 +30,7 @@ dev_example <- function(topic, quiet = FALSE) {
 #' @param test if `TRUE`, code in \code{\\donttest{}} will be commented
 #'   out. If `FALSE`, code in \code{\\testonly{}} will be commented out. This
 #'   parameter is only used in R 3.2 and greater.
-#' @param run if `TRUE`, code in \code{\\dontrun{}} will be commented
+#' @param run if `FALSE`, code in \code{\\dontrun{}} will be commented
 #'   out.
 #' @param env Environment in which code will be run.
 #' @param macros Custom macros to use to parse the `.Rd` file. See the

--- a/man/dev_example.Rd
+++ b/man/dev_example.Rd
@@ -21,7 +21,7 @@ run_example(path, test = FALSE, run = FALSE, env = new.env(parent =
 out. If \code{FALSE}, code in \code{\\testonly{}} will be commented out. This
 parameter is only used in R 3.2 and greater.}
 
-\item{run}{if \code{TRUE}, code in \code{\\dontrun{}} will be commented
+\item{run}{if \code{FALSE}, code in \code{\\dontrun{}} will be commented
 out.}
 
 \item{env}{Environment in which code will be run.}


### PR DESCRIPTION
Looks like examples in `\dontrun{}` are commented out when `run` is set to FALSE. Current docs suggest this behaviour is expected when `run = TRUE`. 

The easiest fix is to update docs in both `pkgload` and `devtools` to match the observed behaviour.  Since the default value for `run` is FALSE in `pkgload`, I assume that this is the desired behaviour in `devtools`. See `devtools` pull request [#2146](https://github.com/r-lib/devtools/pull/2146).

Alternatively, to correct the behaviour to match that of the docs, we need to remove the negation  before `run` in following lines:
https://github.com/r-lib/pkgload/blob/1b1adc39628671f2ea4256f0bebcdb76e1f89f45/R/dev-example.r#L49-L64

The second approach will result in no new changes having to be made to `devtools`.

Happy to update/remove pull requests with the necessary changes that you would prefer.

Dillon