### PR TITLE
Don't fail if S3 registration fails

### DIFF
--- a/R/namespace-env.r
+++ b/R/namespace-env.r
@@ -192,7 +192,7 @@ register_s3 <- function(path = ".") {
   nsInfo <- parse_ns_file(path)
 
   # Adapted from loadNamespace
-  registerS3methods(nsInfo$S3methods, package, ns_env(package))
+  try(registerS3methods(nsInfo$S3methods, package, ns_env(package))
 }
 
 


### PR DESCRIPTION
This makes it a bit easier to redocument yourself out of certain situations where you have an S3 method declaration for a generic that no longer exists.