### PR TITLE
Improvements for S3 unloading

### DIFF
--- a/R/load.r
+++ b/R/load.r
@@ -122,7 +122,7 @@ load_all <- function(path = ".", reset = TRUE, compile = NA,
   # Unloading S3 methods manually will avoid lazy-load
   # errors when the new package is loaded overtop the old one
   if (is_loaded(package)) {
-    s3_unload(package)
+    s3_unregister(package)
   }
 
   # Check description file is ok

--- a/R/load.r
+++ b/R/load.r
@@ -119,12 +119,6 @@ load_all <- function(path = ".", reset = TRUE, compile = NA,
     on.exit(compiler::enableJIT(oldEnabled), TRUE)
   }
 
-  # Unloading S3 methods manually will avoid lazy-load
-  # errors when the new package is loaded overtop the old one
-  if (is_loaded(package)) {
-    s3_unregister(package)
-  }
-
   # Check description file is ok
   check <- ("tools" %:::% ".check_package_description")(
     package_file("DESCRIPTION", path = path))

--- a/R/unload.r
+++ b/R/unload.r
@@ -117,7 +117,7 @@ unload_dll <- function(package) {
   invisible()
 }
 
-s3_unload <- function(package) {
+s3_unregister <- function(package) {
   ns <- ns_env(package)
   ns_defs <- parse_ns_file(system.file(package = package))
   methods <- ns_defs$S3methods[, 1:2, drop = FALSE]

--- a/R/unload.r
+++ b/R/unload.r
@@ -49,6 +49,11 @@ unload <- function(package = pkg_name(), quiet = FALSE) {
     eapply(ns_env(package), force, all.names = TRUE)
   }
 
+  # Unloading S3 methods manually avoids lazy-load errors when the new
+  # package is loaded overtop the old one. It also prevents removed
+  # methods from staying registered.
+  s3_unregister(package)
+
   # S4 classes that were created by the package need to be removed in a special way.
   remove_s4_classes(package)
 

--- a/R/unload.r
+++ b/R/unload.r
@@ -140,6 +140,7 @@ s3_unload <- function(package) {
       next
     }
 
-    table[[paste0(method, collapse = ".")]] <- NULL
+    nm <- paste0(method, collapse = ".")
+    env_unbind(table, nm)
   }
 }


### PR DESCRIPTION
* Actually unbind methods instead of assigning to `NULL`.

* Rename to `s3_unregister()` for consistency with `s3_register()`.

* Run from `unload()` rather than `load_all()`.