### PR TITLE
Drop warning about unloadNamespace

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pkgload (development version)
 
+* `unload()` no longer warns when it can't unload a namespace.
+
 # pkgload 1.2.0
 
 * Fix test failure in R 4.1 with regards to S4 method registration

--- a/R/unload.r
+++ b/R/unload.r
@@ -54,11 +54,6 @@ unload <- function(package = pkg_name(), quiet = FALSE) {
   }, error = function(e) FALSE)
 
   if (!unloaded) {
-    if (!quiet) {
-      cli::cli_alert_danger("unloadNamespace(\"{package}\") failed because another loaded package needs it")
-      cli::cli_alert_info("Forcing unload. If you encounter problems, please restart R.")
-    }
-
     # unloadNamespace() failed before we get to the detach, so need to
     # manually detach
     unload_pkg_env(package)


### PR DESCRIPTION
Since (a) I think we do a lot better than we used to and (b) I've never noticed problems that required a restart.