### PR TITLE
Simplify DESCRIPTION check

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * `load_all(warn_conflicts = TRUE)` becomes more narrow and only warns when a *function* in the global environment masks a *function* in the package, consistent with the docs (#125, #143 @jennybc).
 * `unload()` no longer warns when it can't unload a namespace.
+* `load_all()` no longer does a comprehensive check on the `DESCRIPTION` file when loading, instead just checking that it exists and starts with Package (#149, @malcolmbarrett)
 
 # pkgload 1.2.0
 

--- a/R/load.r
+++ b/R/load.r
@@ -120,16 +120,6 @@ load_all <- function(path = ".", reset = TRUE, compile = NA,
     on.exit(compiler::enableJIT(oldEnabled), TRUE)
   }
 
-  # Check description file is ok
-  check <- ("tools" %:::% ".check_package_description")(
-    package_file("DESCRIPTION", path = path))
-
-  if (length(check) > 0) {
-    msg <- utils::capture.output(("tools" %:::% "print.check_package_description")(check))
-    cli::cli_alert_danger("Invalid DESCRIPTION")
-    cli::cli_code(msg)
-  }
-
   # Compile dll if requested
   if (missing(compile) && !missing(recompile)) {
     compile <- if (isTRUE(recompile)) TRUE else NA

--- a/R/package.r
+++ b/R/package.r
@@ -48,7 +48,7 @@ pkg_path <- function(path = ".") {
       paste0("'", normalizePath(path), "'."),
       "Are you in your project directory,",
       "and does your project have a 'DESCRIPTION' file?"
-    ))
+    ), class = "pkgload_no_desc")
   })
 
   # Strip trailing slashes, which can cause errors on Windows (#73)

--- a/R/package.r
+++ b/R/package.r
@@ -39,7 +39,17 @@ NULL
 #' @describeIn packages Return the normalized package path.
 #' @export
 pkg_path <- function(path = ".") {
-  path <- rprojroot_find_root("DESCRIPTION", path)
+  path <- tryCatch({
+    rprojroot_find_package_root_file(path = path)
+  },
+  error = function(e) {
+    abort(paste(
+      "Could not find a root 'DESCRIPTION' file that starts with '^Package' in",
+      paste0("'", normalizePath(path), "'."),
+      "Are you in your project directory,",
+      "and does your project have a 'DESCRIPTION' file?"
+    ))
+  })
 
   # Strip trailing slashes, which can cause errors on Windows (#73)
   sub("[/\\]$", "", path)

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -9,7 +9,7 @@
   assign("desc_desc", desc::desc, envir = env)
   assign("desc_desc_get", desc::desc_get, envir = env)
   assign("desc_desc_get_version", desc::desc_get_version, envir = env)
-  assign("rprojroot_find_root", rprojroot::find_root, envir = env)
+  assign("rprojroot_find_package_root_file", rprojroot::find_package_root_file, envir = env)
   if (is_installed("testthat")) {
     assign("testthat_source_test_helpers", testthat::source_test_helpers, envir = env)
   } else {

--- a/tests/testthat/test-load.r
+++ b/tests/testthat/test-load.r
@@ -77,3 +77,10 @@ test_that("reloading a package unloads deleted S3 methods", {
   load_all("testS3removed2")
   expect_equal(as.character(x), character())
 })
+
+test_that("load_all() errors when no DESCRIPTION found", {
+  withr::with_tempdir({
+    expect_error(load_all(), class = "pkgload_no_desc")
+  })
+})
+


### PR DESCRIPTION
This PR removes the tools-based DESCRIPTION file check and uses rprojroot to make a simpler check that the `DESCRIPTION` file exists in the project root and that it begins with `^Package`.  `pkg_path()` was already using rprojroot and was making this simpler check, so I beefed up that code a bit to make a clearer error message for the context. 

This PR will simplify the use of loading non-package projects and closes #147. 

Would it be helpful to add a test for a directory with an invalid pkg name and/or a directory without a `DESCRIPTION` file?