### PR TITLE
Force rlang bindings on unload

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # pkgload (development version)
 
-* Fixed issues when using `load_all()` on rlang.
+* pkgload now forces all bindings on unload. This fixes errors and inconsistencies when dangling references force lazy bindings after unload or reload.
 
 * `load_all()` now restores S3 methods registered by third party packages (#163).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,11 @@
 # pkgload (development version)
 
+* Fixed issues when using `load_all()` on rlang.
+
 * `load_all()` now restores S3 methods registered by third party packages (#163).
 
 * `load_dll()` will now preserve the DLL name when loading instead of always using the package name. This allows packages to include DLL's with different names (#162, @dfalbel).
+
 
 # pkgload 1.2.1
 

--- a/R/namespace-env.r
+++ b/R/namespace-env.r
@@ -246,7 +246,12 @@ unregister_namespace <- function(name = NULL) {
   # resulting in "Error in unload(pkg) : internal error -3 in R_decompress1".
   # If we simply force them first, then they will remain available for use
   # later. This also makes it possible to use `load_all()` on pkgload itself.
-  if (name == "pkgload") {
+  #
+  # Since we use rlang itself to create new namespaces we also need to
+  # force all its bindings. Forcing prevents the lazy bindings to be
+  # resolved in the new partially created namespace which can lead to
+  # various issues.
+  if (name %in% c("pkgload", "rlang")) {
     eapply(ns_env(name), force, all.names = TRUE)
   }
 

--- a/tests/testthat/test-load.r
+++ b/tests/testthat/test-load.r
@@ -54,16 +54,19 @@ test_that("warn_if_conflicts does not warn for conflicts when one of the objects
   expect_warning(warn_if_conflicts("pkg", e1, e2), NA)
 })
 
-test_that("loading multiple times doesn't force bindings", {
+test_that("unloading or reloading forces bindings", {
   forced <- FALSE
 
   withCallingHandlers(
     forced = function(...) forced <<- TRUE, {
+      # Allow running test interactively
+      on.exit(unload("testLoadLazy"))
+
       load_all("testLoadLazy")
       expect_false(forced)
 
       load_all("testLoadLazy")
-      expect_false(forced)
+      expect_true(forced)
     }
   )
 })


### PR DESCRIPTION
To prevent lazy rlang bindings to be resolved in the new partially created namespace when forced from pkgload itself.