### PR TITLE
Reuse the provided dllname

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pkgload (development version)
 
+* `load_dll()` will now preserve the DLL name when loading instead of always using the package name. This allows packages to include DLL's with different names (#162, @dfalbel).
+
 # pkgload 1.2.1
 
 * `unload()` no longer unregisters methods for generics of the package being unloaded. This way dangling references to generics defined in the stale namespace still work as expected (r-lib/vctrs#1341).

--- a/R/load-dll.r
+++ b/R/load-dll.r
@@ -90,7 +90,7 @@ library.dynam2 <- function(path = ".", lib = "") {
   # The .so should have the package name so that R can find the
   # `R_init_` function by itself.
   dll_copy_dir <- tempfile("pkgload")
-  dll_copy_file <- file.path(dll_copy_dir, paste0(pkg_name(path), dyn_ext))
+  dll_copy_file <- file.path(dll_copy_dir, dllname)
   dir.create(dll_copy_dir)
   file.copy(dllfile, dll_copy_file)
 


### PR DESCRIPTION
We have a package that due to shared library name collisions we had to rename the generated .so to something else. In that case we rename it from `torch.so` to `torchpkg.so`.

A recent change in #133 uses a temporary file that has the same name as the package

https://github.com/r-lib/pkgload/pull/133/files#diff-33e8edea32dfc4630f62c402513e58979a315710778bc94dde36fb56c942a80eR92-R95

But this causes problems when the DLL being loaded doesn't have the same name as the R package.

This PR proposes to reuse the DLL name that was provided to `library.dinam2` to fix the problem.
