### PR TITLE
Use bindtextdomain() hack to reset cache

### DIFF
--- a/R/po.R
+++ b/R/po.R
@@ -4,25 +4,12 @@ load_po <- function(package, path) {
     return()
   }
 
-  # Clean up previous copies
-  unlink(temp_po_dirs(package), recursive = TRUE, force = TRUE)
+  # Reset cache to avoid gettext() retrieving cached value
+  # See <https://bugs.r-project.org/show_bug.cgi?id=18055> for details
+  bindtextdomain("reset", withr::local_tempdir())
 
-  # Create new copy of translations in temp dir
-  tmp <- tempfile(temp_po_prefix(package))
-  dir.create(tmp, showWarnings = FALSE)
-  tmp_po <- file.path(tmp, "po")
-  file.copy(po_path, tmp, recursive = TRUE)
-
-  bindtextdomain(paste0("R-", package), tmp_po) # R level messages
-  bindtextdomain(package, tmp_po) # C level messages
+  bindtextdomain(paste0("R-", package), po_path) # R level messages
+  bindtextdomain(package, po_path) # C level messages
 
   invisible()
-}
-
-temp_po_prefix <- function(package) {
-  paste0("pkgload-po-", package, "-")
-}
-
-temp_po_dirs <- function(package) {
-  dir(tempdir(), paste0("^", temp_po_prefix(package)), full.names = TRUE)
 }

--- a/tests/testthat/test-po.R
+++ b/tests/testthat/test-po.R
@@ -4,7 +4,4 @@ test_that("translation domain correctly loaded", {
 
   withr::local_envvar(LANGUAGE = "fr")
   expect_equal(hello(), "Bonjour")
-
-  load_all(test_path("testTranslations"))
-  expect_equal(length(temp_po_dirs("testTranslations")), 1)
 })


### PR DESCRIPTION
Per https://github.com/r-lib/withr/pull/183, I think this should be adequate.

Let me know if you think I should construct a test that illustrates the problem and the fix.