### PR TITLE
Demote user hook errors to proper warning conditions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Imports:
     crayon,
     desc,
     methods,
-    rlang,
+    rlang (>= 0.99.0.9001),
     rprojroot,
     rstudioapi,
     utils,
@@ -32,6 +32,8 @@ Suggests:
     pkgbuild,
     Rcpp,
     testthat
+Remotes:
+    r-lib/rlang
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,16 @@
 # pkgload (development version)
 
+* Errors thrown in user hooks are now demoted to a warning
+  condition. Previously they were demoted using `try()`, making it
+  harder to debug them.
+
+
 # pkgload 1.2.4
 
 * Lionel Henry is now the maintainer.
 
 * `load_all()` automatically registers package translations, if found.
+
 
 # pkgload 1.2.3
 
@@ -13,6 +19,7 @@
 * `load_all()` now restores S3 methods registered by third party packages (#163).
 
 * `load_dll()` will now preserve the DLL name when loading instead of always using the package name. This allows packages to include DLL's with different names (#162, @dfalbel).
+
 
 # pkgload 1.2.2
 
@@ -29,6 +36,7 @@
 * `load_all()` no longer does a comprehensive check on the `DESCRIPTION` file when loading, instead just checking that it exists and starts with Package (#149, @malcolmbarrett)
 
 * `unload()` no longer warns when it can't unload a namespace.
+
 
 # pkgload 1.2.0
 
@@ -65,6 +73,7 @@
 
 * If `load_all()` attaches testthat, it automatically suppresses conflicts.
 
+
 # pkgload 1.1.0
 
 * `dev_example()` now works after removing an inconsistent call to `load_all()` (@riccardoporreca, #122).
@@ -74,6 +83,7 @@
 * `run_example()` arguments `run` and `test` are deprecated in favor of the (hopefully) more clear `run_dontrun` and `run_donttest` (#107).
 
 * Internal fixes for compatibility with the future 4.1.0 release.
+
 
 # pkgload 1.0.2
 
@@ -85,6 +95,7 @@
 * `load_all()` gains a `compile` argument which controls more finely whether to
   compile the code or not. The `recompile` argument is now deprecated and will
   be removed in a future version of pkgload.
+
 
 # pkgload 1.0.1
 

--- a/R/run-loadhooks.r
+++ b/R/run-loadhooks.r
@@ -59,10 +59,16 @@ run_user_hook <- function(package, hook) {
       fun(package),
       error = function(cnd) {
         msg <- sprintf(
-          "Problem while running user %s hook for package %s.",
+          "Problem while running user `%s` hook for package %s.",
           hook_name,
           package
         )
+
+        name <- env_name(topenv(fn_env(fun)))
+        if (nzchar(name)) {
+          msg <- c(msg, i = sprintf("The hook inherits from `%s`.", name))
+        }
+
         warn(msg, parent = cnd)
       }
     )

--- a/R/run-loadhooks.r
+++ b/R/run-loadhooks.r
@@ -45,12 +45,28 @@ run_user_hook <- function(package, hook) {
   hook_name <- trans[hook]
 
   metadata <- dev_meta(package)
-  if (isTRUE(metadata[[hook_name]])) return(FALSE)
+  if (isTRUE(metadata[[hook_name]])) {
+    return(FALSE)
+  }
 
   hooks <- getHook(packageEvent(package, hook_name))
-  if (length(hooks) == 0) return(FALSE)
+  if (length(hooks) == 0) {
+    return(FALSE)
+  }
 
-  for(fun in rev(hooks)) try(fun(package))
+  for (fun in rev(hooks)) {
+    try_catch(
+      fun(package),
+      error = function(cnd) {
+        msg <- sprintf(
+          "Problem while running user %s hook for package %s.",
+          hook_name,
+          package
+        )
+        warn(msg, parent = cnd)
+      }
+    )
+  }
   metadata[[hook_name]] <- TRUE
   invisible(TRUE)
 }


### PR DESCRIPTION
Instead of using `try()`. Improves debuggability since the warning can be inspected by `recover()` etc.

Also makes the error more informative. Before:

```r
#> Error : 'knit_engines' is not an exported object from 'namespace:knitr'
```

After:

```r
#> Warning message:
#> Problem while running user `onLoad` hook for package knitr.
#>   ℹ The hook inherits from `namespace:glue`.
#> Caused by error:
#>   'knit_engines' is not an exported object from 'namespace:knitr'
```