### PR TITLE
Seal namespace after loading

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,10 @@
 * User `onLoad` hooks are now run after exports have been
   populated. This allows the hook to use exported functions.
 
+* The loaded namespace is now locked just before user `onLoad` hooks
+  are run. This better reproduced the namespace sealing behaviour of
+  regular loading.
+
 * Errors thrown in user hooks are now demoted to a warning
   condition. Previously they were demoted using `try()`, making it
   harder to debug them.

--- a/R/load.r
+++ b/R/load.r
@@ -175,7 +175,9 @@ load_all <- function(path = ".",
     }
   }
 
-  if (!is_loaded(package)) {
+  if (is_loaded(package)) {
+    rlang::env_unlock(ns_env(package))
+  } else {
     create_ns_env(path)
   }
 
@@ -212,6 +214,8 @@ load_all <- function(path = ".",
   setup_ns_exports(path, export_all, export_imports)
 
   run_ns_load_actions(package)
+  lockEnvironment(ns_env(package))
+
   run_user_hook(package, "load")
 
   # Set up the package environment ------------------------------------

--- a/tests/testthat/testUserLoadHook/R/testUserLoadHook.R
+++ b/tests/testthat/testUserLoadHook/R/testUserLoadHook.R
@@ -1,7 +1,11 @@
 .onLoad <- function(...) {
+  stopifnot(!environmentIsLocked(asNamespace("testUserLoadHook")))
+
   setHook(
     packageEvent("testUserLoadHookUpstream", "onLoad"),
     function(...) {
+      stopifnot(environmentIsLocked(asNamespace("testUserLoadHookUpstream")))
+
       # The package exports are populated when user onLoad hooks are run
       stopifnot(is.null(testUserLoadHookUpstream::foo()))
 


### PR DESCRIPTION
Closes #190

With this change, irregular mutations of the namespace by dev code will cause an error during development as well, rather than just in installed code.

Also this improves the behaviour of our workarounds for detecting completely loaded namespaces, e.g. https://github.com/r-lib/rlang/blob/f4c6d140ad82c041ba60d6d3665107dd4d0343a1/R/aaa.R#L144