### PR TITLE
Lazily import `load_all()` dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Imports:
     desc,
     glue,
     methods,
-    rlang (>= 1.0.0),
+    rlang (>= 1.0.2),
     rprojroot,
     utils,
     withr (>= 2.4.3)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # pkgload (development version)
 
+* `load_all()` now imports its dependencies lazily to avoid parallel
+  installation issues (#89).
+
 * Unknown Rd macros no longer trigger a warning when building the
   package topic index (#119).
 

--- a/R/unload.r
+++ b/R/unload.r
@@ -81,6 +81,11 @@ unload <- function(package = pkg_name(), quiet = FALSE) {
 #' @rdname unload
 #' @export
 unregister <- function(package = pkg_name()) {
+  # Before unregistering anything, force all imported functions that
+  # might be needed during package reloading, in case they come from
+  # `package`
+  force_load_all_deps()
+
   unload_pkg_env(package)
   unregister_methods(package)
   unregister_namespace(package)

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -1,27 +1,49 @@
 .onLoad <- function(libname, pkgname) {
-  # These withr functions are used in load_all() so need to exist in the
-  # devtools namespace so the withr namespace is not prematurely loaded by `::`
-  # during a load_all() call
-  env <- asNamespace(pkgname)
-  assign("withr_with_dir", withr::with_dir, envir = env)
-  assign("withr_with_collate", withr::with_collate, envir = env)
-  assign("withr_with_envvar", withr::with_envvar, envir = env)
-  assign("desc_desc", desc::desc, envir = env)
-  assign("desc_desc_get", desc::desc_get, envir = env)
-  assign("desc_desc_get_version", desc::desc_get_version, envir = env)
-  assign("rprojroot_find_package_root_file", rprojroot::find_package_root_file, envir = env)
-  if (is_installed("testthat")) {
-    assign("testthat_source_test_helpers", testthat::source_test_helpers, envir = env)
-  } else {
-    assign("testthat_source_test_helpers", function(...) TRUE, envir = env)
-  }
+  run_on_load()
+  ns <- ns_env(pkgname)
 
+  nms <- fn_env(onload_assign)$names
+  funs <- fn_env(onload_assign)$funs
 
-  nms <- environment(onload_assign)$names
-  funs <- environment(onload_assign)$funs
   for (i in seq_along(nms)) {
-    assign(nms[[i]], eval(funs[[i]], envir = env), envir = env)
+    env_poke(ns, nms[[i]], eval(funs[[i]], ns))
   }
+}
 
-  invisible()
+# These functions are used in load_all() so need to exist in the
+# devtools namespace so the withr namespace is not prematurely loaded
+# by `::` during a load_all() call.
+#
+# They are lazily assigned to avoid racing issues while installing in
+# parallel (see #89), and forced via `force_load_all_deps()` before
+# unregistering namespaces.
+on_load({
+  withr_with_dir %<~% withr::with_dir
+  withr_with_collate %<~% withr::with_collate
+  withr_with_envvar %<~% withr::with_envvar
+
+  desc_desc %<~% desc::desc
+  desc_desc_get %<~% desc::desc_get
+  desc_desc_get_version %<~% desc::desc_get_version
+
+  rprojroot_find_package_root_file %<~% rprojroot::find_package_root_file
+
+  if (is_installed("testthat")) {
+    testthat_source_test_helpers %<~% testthat::source_test_helpers
+  } else {
+    testthat_source_test_helpers %<~% function(...) TRUE
+  }
+})
+
+force_load_all_deps <- function() {
+  list(
+    withr_with_dir,
+    withr_with_collate,
+    withr_with_envvar,
+    desc_desc,
+    desc_desc_get,
+    desc_desc_get_version,
+    rprojroot_find_package_root_file,
+    testthat_source_test_helpers
+  )
 }


### PR DESCRIPTION
Closes #89.