### PR TITLE
Document differences with `loadNamespace()` and `library()`

### DIFF
--- a/R/load.R
+++ b/R/load.R
@@ -29,6 +29,23 @@
 #' `is_loading()` returns `TRUE` when it is called while `load_all()`
 #' is running. This may be useful e.g. in onLoad hooks.
 #'
+#' @section Differences with `loadNamespace()` and `library()`:
+
+#' `load_all()` tries its best to reproduce the behaviour of
+#' [loadNamespace()] and [library()]. However it deviates from normal
+#' package loading in several ways.
+#'
+#' - It doesn't install the package on disk, so [system.file()] has no
+#'   way of determining the location of the development files. To work
+#'   around this, pkgload installs its own version of [system.file()]
+#'   on the search path to make it easier to use interactively while
+#'   developing. However this definition is only visible to the global
+#'   environment, not to the namespaces of third party packages.
+#'
+#'   One workaround for other packages to see the development files of
+#'   your package while you're developing with devtools is for them to
+#'   use `fs::path_package()` instead of `system.file()`.
+#'
 #' @section Namespaces:
 #' The namespace environment `<namespace:pkgname>`, is a child of
 #' the imports environment, which has the name attribute

--- a/R/load.R
+++ b/R/load.R
@@ -46,6 +46,10 @@
 #'   your package while you're developing with devtools is for them to
 #'   use `fs::path_package()` instead of `system.file()`.
 #'
+#' - Whereas `loadNamespace()` and `library()` only load package
+#'   dependencies when they are needed, `load_all()` loads all packages
+#'   referenced in `Imports` at load time.
+#'
 #' @section Namespaces:
 #' The namespace environment `<namespace:pkgname>`, is a child of
 #' the imports environment, which has the name attribute

--- a/man/load_all.Rd
+++ b/man/load_all.Rd
@@ -89,6 +89,25 @@ helpers are run during package loading.
 \code{is_loading()} returns \code{TRUE} when it is called while \code{load_all()}
 is running. This may be useful e.g. in onLoad hooks.
 }
+\section{Differences with \code{loadNamespace()} and \code{library()}}{
+
+\code{load_all()} tries its best to reproduce the behaviour of
+\code{\link[=loadNamespace]{loadNamespace()}} and \code{\link[=library]{library()}}. However it deviates from normal
+package loading in several ways.
+\itemize{
+\item It doesn't install the package on disk, so \code{\link[=system.file]{system.file()}} has no
+way of determining the location of the development files. To work
+around this, pkgload installs its own version of \code{\link[=system.file]{system.file()}}
+on the search path to make it easier to use interactively while
+developing. However this definition is only visible to the global
+environment, not to the namespaces of third party packages.
+
+One workaround for other packages to see the development files of
+your package while you're developing with devtools is for them to
+use \code{fs::path_package()} instead of \code{system.file()}.
+}
+}
+
 \section{Namespaces}{
 
 The namespace environment \verb{<namespace:pkgname>}, is a child of

--- a/man/load_all.Rd
+++ b/man/load_all.Rd
@@ -105,6 +105,9 @@ environment, not to the namespaces of third party packages.
 One workaround for other packages to see the development files of
 your package while you're developing with devtools is for them to
 use \code{fs::path_package()} instead of \code{system.file()}.
+\item Whereas \code{loadNamespace()} and \code{library()} only load package
+dependencies when they are needed, \code{load_all()} loads all packages
+referenced in \code{Imports} at load time.
 }
 }
 


### PR DESCRIPTION
- Document how the package files are not installed on disk and the limitations this entails with `system.file()`. Closes #69. I'd rather avoid changing the imports of all packages since the fate of `env_unlock()` is uncertain, so hopefully the suggested workaround with `fs::path_package()` is sufficient for now.

- Document that `load_all()` loads all packages in Imports, closes #76.