### PR TITLE
Lock the package environment

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -58,6 +58,9 @@
   are run. This better reproduced the namespace sealing behaviour of
   regular loading.
 
+  The package environment environment is now locked as well before
+  both the user and package `onAttach` hooks are run.
+
 * Errors thrown in user hooks are now demoted to a warning
   condition. Previously they were demoted using `try()`, making it
   harder to debug them.

--- a/R/load.R
+++ b/R/load.R
@@ -240,7 +240,12 @@ load_all <- function(path = ".",
   setup_ns_exports(path, export_all, export_imports)
 
   run_ns_load_actions(package)
-  lockEnvironment(ns_env(package))
+
+  ns <- ns_env(package)
+  lockEnvironment(ns)
+  for (nm in names(ns)) {
+    lockBinding(nm, ns)
+  }
 
   run_user_hook(package, "load")
 

--- a/tests/testthat/test-load-hooks.R
+++ b/tests/testthat/test-load-hooks.R
@@ -60,25 +60,23 @@ test_that("onLoad and onAttach", {
   nsenv <- ns_env("testLoadHooks")
   pkgenv <- pkg_env("testLoadHooks")
 
+  the <- nsenv$the
+  expect_true(is_reference(the, pkgenv$the))
+
   # normalizePath is needed so that capitalization differences on
   # case-insensitive platforms won't cause errors.
-  expect_equal(normalizePath(nsenv$onload_lib), normalizePath(getwd()))
-  expect_equal(normalizePath(nsenv$onattach_lib), normalizePath(getwd()))
+  expect_equal(normalizePath(the$onload_lib), normalizePath(getwd()))
+  expect_equal(normalizePath(the$onattach_lib), normalizePath(getwd()))
+
+  expect_false(nsenv$ns_locked)
+  expect_true(nsenv$pkg_locked)
 
   # a: modified by onLoad in namespace env
   # b: modified by onAttach in namespace env
   # c: modified by onAttach in package env
-  # In a normal install+load, b can't be modified by onAttach because
-  # the namespace is locked before onAttach. But it can be modified when
-  # using load_all.
-  expect_equal(nsenv$a, 2)
-  expect_equal(nsenv$b, 2) # This would be 1 in normal install+load
-  expect_equal(nsenv$c, 1)
-
-  expect_equal(pkgenv$a, 2)
-  expect_equal(pkgenv$b, 1)
-  expect_equal(pkgenv$c, 2)
-
+  expect_equal(the$a, 2)
+  expect_equal(the$b, 2)
+  expect_equal(the$c, 2)
 
   # ===================================================================
   # Loading again without reset won't change a, b, and c in the
@@ -86,18 +84,14 @@ test_that("onLoad and onAttach", {
   # the existing namespace values will be copied over to the package
   # environment
   load_all("testLoadHooks", reset = FALSE)
+
   # Shouldn't form new environments
   expect_identical(nsenv, ns_env("testLoadHooks"))
   expect_identical(pkgenv, pkg_env("testLoadHooks"))
 
-  # namespace and package env values should be the same
-  expect_equal(nsenv$a, 2)
-  expect_equal(nsenv$b, 2)
-  expect_equal(nsenv$c, 1)
-  expect_equal(pkgenv$a, 2)
-  expect_equal(pkgenv$b, 2)
-  expect_equal(pkgenv$c, 1)
-
+  expect_equal(the$a, 2)
+  expect_equal(the$b, 2)
+  expect_equal(the$c, 2)
 
   # ===================================================================
   # With reset=TRUE, there should be new package and namespace
@@ -106,17 +100,17 @@ test_that("onLoad and onAttach", {
   load_all("testLoadHooks", reset = TRUE)
   nsenv2 <- ns_env("testLoadHooks")
   pkgenv2 <- pkg_env("testLoadHooks")
+
+  the2 <- nsenv2$the
+
   # Should form new environments
   expect_false(identical(nsenv, nsenv2))
   expect_false(identical(pkgenv, pkgenv2))
 
   # Values should be same as first time
-  expect_equal(nsenv2$a, 2)
-  expect_equal(nsenv2$b, 2)
-  expect_equal(nsenv2$c, 1)
-  expect_equal(pkgenv2$a, 2)
-  expect_equal(pkgenv2$b, 1)
-  expect_equal(pkgenv2$c, 2)
+  expect_equal(the2$a, 2)
+  expect_equal(the2$b, 2)
+  expect_equal(the2$c, 2)
 
   unload("testLoadHooks")
 
@@ -126,18 +120,16 @@ test_that("onLoad and onAttach", {
   load_all("testLoadHooks")
   nsenv3 <- ns_env("testLoadHooks")
   pkgenv3 <- pkg_env("testLoadHooks")
+  the3 <- nsenv3$the
 
   # Should form new environments
   expect_false(identical(nsenv, nsenv3))
   expect_false(identical(pkgenv, pkgenv3))
 
   # Values should be same as first time
-  expect_equal(nsenv3$a, 2)
-  expect_equal(nsenv3$b, 2)
-  expect_equal(nsenv3$c, 1)
-  expect_equal(pkgenv3$a, 2)
-  expect_equal(pkgenv3$b, 1)
-  expect_equal(pkgenv3$c, 2)
+  expect_equal(the3$a, 2)
+  expect_equal(the3$b, 2)
+  expect_equal(the3$c, 2)
 
   unload("testLoadHooks")
 })

--- a/tests/testthat/testUserLoadHookError/R/testUserLoadHookError.R
+++ b/tests/testthat/testUserLoadHookError/R/testUserLoadHookError.R
@@ -1,15 +1,17 @@
+the <- new.env()
+
 # Can't fully reset onLoad hook so only run once in case of repeated
 # `test()` calls
-ran_already <- FALSE
+the$ran_already <- FALSE
 
 .onLoad <- function(...) {
   setHook(
     packageEvent("testUserLoadHookUpstream", "onLoad"),
     function(...) {
-      if (ran_already) {
+      if (the$ran_already) {
         return()
       }
-      ran_already <<- TRUE
+      the$ran_already <- TRUE
 
       rlang::signal("", "hook_was_run_error")
       stop("The message.")


### PR DESCRIPTION
This better reproduces the behaviour of namespace loading.