### PR TITLE
Minor FR: Change the conflict-removing message in pkg_load()

### DIFF
--- a/R/load.R
+++ b/R/load.R
@@ -323,7 +323,7 @@ warn_if_conflicts <- function(package, env1, env2) {
 
   directions <- c(
     "i" = cli::col_silver("Did you accidentally source a file rather than using `load_all()`?"),
-    " " = cli::col_silver(glue::glue("Run {run_rm} to remove the conflicts."))
+    " " = cli::col_silver(glue::glue("Run the following code to remove the conflicts: {run_rm}"))
   )
 
   cli::cli_warn(


### PR DESCRIPTION
Hi,

The message from `pkg_load()` is very convenient when you accidentally source a file instead of loading your package:

```bash
> devtools::load_all(".")
ℹ Loading crosstable
[1] "Helper loaded"
Warning: 
  ── Conflicts ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── crosstable conflicts ──
✖ compact()            masks crosstable::compact()
✖ compact.crosstable() masks crosstable::compact.crosstable()
✖ compact.data.frame() masks crosstable::compact.data.frame()
… and 5 more

Did you accidentally source a file rather than using `load_all()`?
Run `rm(list = c("compact", "compact.crosstable", "compact.data.frame", "compact.default", "ct
_compact", "ct_compact.crosstable", "ct_compact.data.frame", "ct_compact.default"))` to remove 
the conflicts.
```

However, the code could be much easier to select (for copy-pasting) if it were more separated from the rest.

In this a bit quibbling FR, I've put it at the very end of the sentence, but you might even want to put it in a separate bullet for even better separation.