### PR TITLE
use `.rs.api.previewRd()` again

### DIFF
--- a/R/dev-help.R
+++ b/R/dev-help.R
@@ -57,6 +57,13 @@ print.dev_topic <- function(x, ...) {
   cli::cli_inform(c("i" = "Rendering development documentation for {.val {x$topic}}"))
 
   type <- arg_match0(x$type %||% "text", c("text", "html"))
+
+  # use rstudio's previewRd() is possible
+  if (type == "html" && is_rstudio() && is_installed("rstudioapi") && rstudioapi::hasFun("previewRd")) {
+    return(rstudioapi::callFun("previewRd", x$path))
+  }
+
+  # otherwise render and serve
   file <- fs::path_ext_set(fs::path_file(x$path), type)
 
   # This directory structure is necessary for RStudio to open the

--- a/pkgload.Rproj
+++ b/pkgload.Rproj
@@ -3,7 +3,6 @@ Version: 1.0
 RestoreWorkspace: No
 SaveWorkspace: No
 AlwaysSaveHistory: Default
-QuitChildProcessesOnExit: Default
 
 EnableCodeIndexing: Yes
 UseSpacesForTab: Yes

--- a/tests/testthat/test-help.R
+++ b/tests/testthat/test-help.R
@@ -107,6 +107,8 @@ test_that("complex expressions are checked", {
 })
 
 test_that("can use macros in other packages (#120)", {
+  expect_true(has_rd_macros(test_path("testMacroDownstream/")))
+
   skip_if_not_installed("mathjaxr")
 
   load_all(test_path("testMacroDownstream"))


### PR DESCRIPTION
related to https://github.com/rstudio/rstudio/pull/12111 which fixes `.rs.Rd2HTML()` to load the Rd macros correctly. 