### PR TITLE
Clear cache if topic not found

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pkgload (development version)
 
+* Shimmed `?` now works even if you've renamed the documentation topic (#220).
+
 # pkgload 1.3.0
 
 * `load_all()` now calls `rlang::check_installed()` to prompt whether

--- a/R/dev-help.R
+++ b/R/dev-help.R
@@ -26,9 +26,16 @@ dev_help <- function(topic,
                      dev_packages = NULL,
                      stage = "render",
                      type = getOption("help_type")) {
+
   loc <- dev_topic_find(topic, dev_packages)
 
-  if (is.null(loc$path)) {
+  if (!is.null(loc$path) && !file.exists(loc$path)) {
+    # Documentation topic might have moved, so reset topic index and try again
+    dev_topic_index_reset(loc$pkg)
+    loc <- dev_topic_find(topic, dev_packages)
+  }
+
+  if (is.null(loc$path) || !file.exists(loc$path)) {
     cli::cli_abort("Can't find development topic {.arg {topic}}.")
   }
 

--- a/R/dev-help.R
+++ b/R/dev-help.R
@@ -26,7 +26,6 @@ dev_help <- function(topic,
                      dev_packages = NULL,
                      stage = "render",
                      type = getOption("help_type")) {
-
   loc <- dev_topic_find(topic, dev_packages)
 
   if (!is.null(loc$path) && !file.exists(loc$path)) {

--- a/R/dev-help.R
+++ b/R/dev-help.R
@@ -28,13 +28,13 @@ dev_help <- function(topic,
                      type = getOption("help_type")) {
   loc <- dev_topic_find(topic, dev_packages)
 
-  if (!is.null(loc$path) && !file.exists(loc$path)) {
+  if (!is.null(loc$path) && !fs::file_exists(loc$path)) {
     # Documentation topic might have moved, so reset topic index and try again
     dev_topic_index_reset(loc$pkg)
     loc <- dev_topic_find(topic, dev_packages)
   }
 
-  if (is.null(loc$path) || !file.exists(loc$path)) {
+  if (is.null(loc$path) || !fs::file_exists(loc$path)) {
     cli::cli_abort("Can't find development topic {.arg {topic}}.")
   }
 

--- a/R/dev-topic.R
+++ b/R/dev-topic.R
@@ -12,16 +12,10 @@ rd_files <- function(path) {
 dev_topic_find <- function(topic, dev_packages = NULL) {
   topic <- dev_topic_parse(topic, dev_packages)
 
-  path <- NULL
-  pkg <- NULL
   for (pkg_name in topic$pkg_names) {
-    path <- dev_topic_path(topic$topic,
-                           path = ns_path(pkg_name))
+    path <- dev_topic_path(topic$topic, path = ns_path(pkg_name))
     if (!is.null(path)) {
-      return(list(
-        path = path,
-        pkg = pkg_name
-      ))
+      return(list(path = path, pkg = pkg_name))
     }
   }
 

--- a/R/shims.R
+++ b/R/shims.R
@@ -12,12 +12,11 @@ insert_imports_shims <- function(package) {
 # help, ?, and system.file.
 insert_global_shims <- function(force = FALSE) {
   if ("devtools_shims" %in% search()) {
-    if (force) {
-      base::detach("devtools_shims")
-    } else {
+    if (!force) {
       # If shims already present, just return
       return()
     }
+    base::detach("devtools_shims")
   }
 
   e <- new.env()

--- a/R/shims.R
+++ b/R/shims.R
@@ -10,9 +10,15 @@ insert_imports_shims <- function(package) {
 
 # Create a new environment as the parent of global, with devtools versions of
 # help, ?, and system.file.
-insert_global_shims <- function() {
-  # If shims already present, just return
-  if ("devtools_shims" %in% search()) return()
+insert_global_shims <- function(force = FALSE) {
+  if ("devtools_shims" %in% search()) {
+    if (force) {
+      base::detach("devtools_shims")
+    } else {
+      # If shims already present, just return
+      return()
+    }
+  }
 
   e <- new.env()
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -2,6 +2,11 @@
   run_on_load()
   ns <- ns_env(pkgname)
 
+  # Force reload global shims if developing pkgload itself
+  if (is_loading()) {
+    insert_global_shims(TRUE)
+  }
+
   nms <- fn_env(onload_assign)$names
   funs <- fn_env(onload_assign)$funs
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -4,7 +4,7 @@
 
   # Force reload global shims if developing pkgload itself
   if (is_loading()) {
-    insert_global_shims(TRUE)
+    insert_global_shims(force = TRUE)
   }
 
   nms <- fn_env(onload_assign)$names

--- a/tests/testthat/test-help.R
+++ b/tests/testthat/test-help.R
@@ -72,6 +72,23 @@ test_that("show_help and shim_question files for devtools-loaded packages", {
     ))
 })
 
+test_that("shim_help and shim_questions works if topic moves", {
+  load_all(test_path('testHelp'))
+  on.exit(unload(test_path('testHelp')))
+
+  foofoo_path <- test_path("testHelp/man/foofoo.Rd")
+  barbar_path <- test_path("testHelp/man/barbar.Rd")
+
+  expect_equal(shim_help("foofoo")$path, normalizePath(foofoo_path))
+  expect_equal(shim_question("foofoo")$path, normalizePath(foofoo_path))
+
+  file.rename(foofoo_path, barbar_path)
+  on.exit(file.rename(barbar_path, foofoo_path))
+
+  expect_equal(shim_help("foofoo")$path, normalizePath(barbar_path))
+  expect_equal(shim_question("foofoo")$path, normalizePath(barbar_path))
+})
+
 test_that("dev_help works with package and function help with the same name", {
   load_all(test_path('testHelp'))
   on.exit(unload(test_path('testHelp')))

--- a/tests/testthat/test-help.R
+++ b/tests/testthat/test-help.R
@@ -83,7 +83,7 @@ test_that("shim_help and shim_questions works if topic moves", {
   expect_equal(shim_question("foofoo")$path, normalizePath(foofoo_path))
 
   file.rename(foofoo_path, barbar_path)
-  on.exit(file.rename(barbar_path, foofoo_path))
+  on.exit(file.rename(barbar_path, foofoo_path), add = TRUE)
 
   expect_equal(shim_help("foofoo")$path, normalizePath(barbar_path))
   expect_equal(shim_question("foofoo")$path, normalizePath(barbar_path))

--- a/tests/testthat/test-help.R
+++ b/tests/testthat/test-help.R
@@ -76,17 +76,22 @@ test_that("shim_help and shim_questions works if topic moves", {
   load_all(test_path('testHelp'))
   on.exit(unload(test_path('testHelp')))
 
-  foofoo_path <- test_path("testHelp/man/foofoo.Rd")
-  barbar_path <- test_path("testHelp/man/barbar.Rd")
+  path_man <- test_path("testHelp/man/")
+  rel_rd_path <- function(x) {
+    as.character(fs::path_rel(x$path, path_man))
+  }
 
-  expect_equal(shim_help("foofoo")$path, normalizePath(foofoo_path))
-  expect_equal(shim_question("foofoo")$path, normalizePath(foofoo_path))
+  expect_equal(rel_rd_path(shim_help("foofoo")), "foofoo.Rd")
+  expect_equal(rel_rd_path(shim_question("foofoo")), "foofoo.Rd")
 
-  file.rename(foofoo_path, barbar_path)
-  on.exit(file.rename(barbar_path, foofoo_path), add = TRUE)
+  fs::file_move(fs::path(path_man, "foofoo.Rd"), fs::path(path_man, "barbar.Rd"))
+  on.exit(
+    fs::file_move(fs::path(path_man, "barbar.Rd"), fs::path(path_man, "foofoo.Rd")),
+    add = TRUE
+  )
 
-  expect_equal(shim_help("foofoo")$path, normalizePath(barbar_path))
-  expect_equal(shim_question("foofoo")$path, normalizePath(barbar_path))
+  expect_equal(rel_rd_path(shim_help("foofoo")), "barbar.Rd")
+  expect_equal(rel_rd_path(shim_question("foofoo")), "barbar.Rd")
 })
 
 test_that("dev_help works with package and function help with the same name", {


### PR DESCRIPTION
Most of the work here was making it possible to work on this - now calling `load_all()` on pkgload will force reload the shims so you get the development version. Also refactored `dev_topic_find()` to make it a bit clearer what it's doing.

Fixes #220