### PR TITLE
Do not assume that no pkgbuild is needed if no /src

### DIFF
--- a/R/load.R
+++ b/R/load.R
@@ -144,11 +144,7 @@ load_all <- function(path = ".",
     on.exit(compiler::enableJIT(oldEnabled), TRUE)
   }
 
-  # Compile dll if requested, we don't ever need to do this if a package doesn't
-  # have a src/ directory
-  if (!dir.exists(file.path(path, "src"))) {
-    compile <- FALSE
-  } else if (missing(compile) && !missing(recompile)) {
+  if (missing(compile) && !missing(recompile)) {
     compile <- if (isTRUE(recompile)) TRUE else NA
   }
 


### PR DESCRIPTION
In some cases a build is still needed, e.g. if
the package has a `./configure` file, like dev
purrr.