### PR TITLE
Update docs for load_all()

### DIFF
--- a/R/load.R
+++ b/R/load.R
@@ -31,7 +31,7 @@
 #'
 #' - If you use \pkg{testthat}, will load all test helpers so you can
 #'   access them interactively. devtools sets the `DEVTOOLS_LOAD`
-#'   environment variable to `"true"` to let you check whether the
+#'   environment variable to the package name to let you check whether the
 #'   helpers are run during package loading.
 #'
 #' `is_loading()` returns `TRUE` when it is called while `load_all()`


### PR DESCRIPTION
Very minor fix.  
The docs state that `load_all()` sets the environment variable `DEVTOOLS_LOAD` to `"true"`.
However, I have found out that it is set to the package name being loaded (since [https://github.com/r-lib/pkgload/commit/250d9e77fc66964a547c9f57d2689ba30ccdcd59](https://github.com/r-lib/pkgload/commit/250d9e77fc66964a547c9f57d2689ba30ccdcd59)).  
This is consistent with {tidyverse}'s [`.onAttach`](https://github.com/tidyverse/tidyverse/blob/8ec2e1ffb739da925952b779925bb806bba8ff99/R/zzz.R#LL18C8-L18C8).
