### PR TITLE
Add missing methods namespace

### DIFF
--- a/R/remove-s4-class.R
+++ b/R/remove-s4-class.R
@@ -139,7 +139,7 @@ contains_backrefs <- function(classname, pkgname, contains) {
 
   # Get a named vector of 'contains', where each item's name is the class,
   # and the value is the package.
-  contain_pkgs <- sapply(contains, "slot", "package")
+  contain_pkgs <- sapply(contains, methods::slot, "package")
 
   mapply(has_subclass_ref, names(contain_pkgs), contain_pkgs, classname, pkgname)
 }

--- a/tests/testthat/test-s4-unload.R
+++ b/tests/testthat/test-s4-unload.R
@@ -4,7 +4,7 @@ local_load_all_quiet()
 # Results are sorted so they can be compared easily to a vector.
 # A contains B  ==  A is a superclass of B
 get_superclasses <- function(class) {
-  superclasses <- vapply(getClass(class)@contains, slot, "superClass",
+  superclasses <- vapply(getClass(class)@contains, methods::slot, "superClass",
     FUN.VALUE = character(1))
 
   sort(unname(superclasses))
@@ -14,7 +14,7 @@ get_superclasses <- function(class) {
 # Results are sorted so they can be compared easily to a vector.
 # A extends B  ==  A is a subclass of B
 get_subclasses <- function(class) {
-  subclasses <- vapply(getClass(class)@subclasses, slot, "subClass",
+  subclasses <- vapply(getClass(class)@subclasses, methods::slot, "subClass",
     FUN.VALUE = character(1))
 
   sort(unname(subclasses))


### PR DESCRIPTION
Fixes #243. There might be other places where the methods namespace is missing but after adding this I could use `load_all()`.