### PR TITLE
Compare to a numeric version

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -16,7 +16,7 @@ compact <- function(x) {
   get(f, envir = asNamespace(p))
 }
 
-is_installed <- function(package, version = 0) {
+is_installed <- function(package, version = "0") {
   installed_version <- tryCatch(utils::packageVersion(package), error = function(e) NA)
   !is.na(installed_version) && installed_version >= version
 }
@@ -180,7 +180,7 @@ single_quote <- function(x) {
 }
 
 ns_s3_methods <- function(pkg) {
- ns_env(pkg)$.__S3MethodsTable__. 
+ ns_env(pkg)$.__S3MethodsTable__.
 }
 
 paste_line <- function(...) {


### PR DESCRIPTION
Part of the response to CRAN's requests related to https://bugs.r-project.org/show_bug.cgi?id=18548

I came across this while trying to figure out why simply loading devtools's namespace tickles the new warning. I'm not sure if this is the whole explanation (it doesn't seem so and yet I can't find anything else yet). But this is definitely a problem as well.

In my hands, on R-devel, with `_R_CALLS_INVALID_NUMERIC_VERSION_` set to `true`, simply attaching pkgload triggers the warning:

```
~/rrr % R

R Under development (unstable) (2023-06-29 r84615) -- "Unsuffered Consequences"
Copyright (C) 2023 The R Foundation for Statistical Computing
Platform: aarch64-apple-darwin20

R is free software and comes with ABSOLUTELY NO WARRANTY.
You are welcome to redistribute it under certain conditions.
Type 'license()' or 'licence()' for distribution details.

  Natural language support but running in an English locale

R is a collaborative project with many contributors.
Type 'contributors()' for more information and
'citation()' on how to cite R or R packages in publications.

Type 'demo()' for some demos, 'help()' for on-line help, or
'help.start()' for an HTML browser interface to help.
Type 'q()' to quit R.

> library(pkgload)
Warning in .make_numeric_version(x, strict, .standard_regexps()$valid_numeric_version) :
  invalid non-character version specification 'x' (type: double)
Calls:
 1: library(pkgload)
 2: tryCatch({
        attr(package, "LibPath") <- which.lib.loc
        ns <- loadNamespace(package, lib.loc)
        env <- attachNamespace(ns, pos = pos, deps, exclude, include.only)
    }, error = function(e) {
        P <- if (!is.null(cc <- conditionCall(e))) 
            paste(" in", deparse(cc)[1L])
        else ""
        msg <- gettextf("package or namespace load failed for %s%s:\n %s", sQuote(package), P, conditionMessage(e))
        if (logical.return && !quietly) 
            message(paste("Error:", msg), domain = NA)
        else stop(msg, call. = FALSE, domain = NA)
    })
 3: tryCatchList(expr, classes, parentenv, handlers)
 4: tryCatchOne(expr, names, parentenv, handlers[[1L]])
 5: doTryCatch(return(expr), name, parentenv, handler)
 6: loadNamespace(package, lib.loc)
 7: runHook(".onLoad", env, package.lib, package)
 8: tryCatch(fun(libname, pkgname), error = identity)
 9: tryCatchList(expr, classes, parentenv, handlers)
10: tryCatchOne(expr, names, parentenv, handlers[[1L]])
11: doTryCatch(return(expr), name, parentenv, handler)
12: fun(libname, pkgname)
13: run_on_load()
14: callback()
15: is_installed("testthat")
16: Ops.numeric_version(installed_version, version)
17: as.numeric_version(e2)
18: numeric_version(x)
19: .make_numeric_version(x, strict, .standard_regexps()$valid_numeric_version)
```

However, after with this PR, the warning goes away.
