### PR TITLE
Set `LC_ALL` in translation test

### DIFF
--- a/R/imports-env.R
+++ b/R/imports-env.R
@@ -4,7 +4,7 @@
 #' package namespace environment, and is a child of `<namespace:base>`,
 #' which is a child of `R_GlobalEnv`.
 #' @keywords internal
-#' @param path TODO: fix doc
+#' @param package The package name as a string.
 #' @seealso [ns_env()] for the namespace environment that
 #'   all the objects (exported and not exported).
 #' @seealso [pkg_env()] for the attached environment that contains

--- a/man/imports_env.Rd
+++ b/man/imports_env.Rd
@@ -7,7 +7,7 @@
 imports_env(package)
 }
 \arguments{
-\item{path}{TODO: fix doc}
+\item{package}{The package name as a string.}
 }
 \description{
 Contains objects imported from other packages. Is the parent of the

--- a/tests/testthat/test-po.R
+++ b/tests/testthat/test-po.R
@@ -11,13 +11,21 @@ test_that("translation domain correctly loaded", {
 })
 
 test_that("modified translations are correctly reloaded", {
+  # Need to also specify `LC_ALL` because `LANGUAGE` is ignored when
+  # `LANG` is set (here via `LC_ALL`) to `C` or `C.UTF-8`
+  with_lang <- function(lc, language, expr) {
+    withr::local_envvar(c(LC_ALL = lc))
+    withr::local_language(language)
+    expr
+  }
+
   pkg <- withr::local_tempdir()
   file.copy(dir(test_path("testTranslations"), full.names = TRUE), pkg, recursive = TRUE)
 
   # Load package and generate translation
   load_all(pkg)
   withr::defer(unload("testTranslations"))
-  withr::with_language("fr", hello())
+  with_lang("fr_FR", "fr", hello())
 
   # Modify .po file
   po_path <- file.path(pkg, "po", "R-fr.po")
@@ -33,5 +41,5 @@ test_that("modified translations are correctly reloaded", {
 
   # Re-load and re-translate
   load_all(pkg)
-  expect_equal(withr::with_language("fr", hello()), "Salut")
+  expect_equal(with_lang("fr_FR", "fr", hello()), "Salut")
 })


### PR DESCRIPTION
Fixes these CRAN failures:

```
══ Failed tests ════════════════════════════════════════════════════════════════
  ── Failure ('test-po.R:7:3'): translation domain correctly loaded ──────────────
  withr::with_language("fr", hello()) (`actual`) not equal to "Bonjour" (`expected`).

  `actual`: "Hello"
  `expected`: "Bonjour"
  ── Failure ('test-po.R:36:3'): modifed translations are correctly reloaded ─────
  withr::with_language("fr", hello()) (`actual`) not equal to "Salut" (`expected`).

  `actual`: "Hello"
  `expected`: "Salut"
```

Kurt helpfully tracked down the failures to these changes in glibc:

```
*********************************************************************
commit 2897b231a6b71ee17d47d3d63f1112b2641a476c
Author: Bruno Haible <bruno@clisp.org>
Date:   Mon Sep 4 15:31:36 2023 +0200

    intl: Treat C.UTF-8 locale like C locale (BZ# 16621)

    The wiki page https://sourceware.org/glibc/wiki/Proposals/C.UTF-8
    says that "Setting LC_ALL=C.UTF-8 will ignore LANGUAGE just like it
    does with LC_ALL=C." This patch implements it.

    * intl/dcigettext.c (guess_category_value): Treat C.<encoding> locale
    like the C locale.

    Reviewed-by: Florian Weimer <fweimer@redhat.com>
*********************************************************************

via

*********************************************************************
  * debian/patches/any/git-c-utf-8-language.diff: backport support from
    upstream to treat C.<encoding> locale like C locale.  Closes: 874160.
*********************************************************************
```