### PR TITLE
make `load_all()` work when dependencies are missing and pak is installed.

### DIFF
--- a/R/package-deps.R
+++ b/R/package-deps.R
@@ -76,7 +76,7 @@ deps_check_installed <- function(path, deps, call = caller_env()) {
   # method does not support Remotes fields.
   action <- function(pkg, ...) {
     if (is_installed("pak")) {
-      deps <- pak::pkg_deps(path, upgrade = FALSE)
+      deps <- pak::local_deps(path, upgrade = FALSE)
       deps <- deps[deps$package %in% pkg, ]
       pak::pkg_install(deps$ref, ask = FALSE)
     } else if (is_installed("remotes")) {


### PR DESCRIPTION
Closes #261. fixed the issue for me when calling `load_all()` with a package with missing dependencies and the prompt to install works and the missing package installs.