### PR TITLE
Docs/269 identify loaded packages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,4 +46,4 @@ Config/testthat/parallel: TRUE
 Config/testthat/start-first: dll
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,4 +46,4 @@ Config/testthat/parallel: TRUE
 Config/testthat/start-first: dll
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.2.3

--- a/R/load.R
+++ b/R/load.R
@@ -36,6 +36,8 @@
 #'
 #' `is_loading()` returns `TRUE` when it is called while `load_all()`
 #' is running. This may be useful e.g. in `.onLoad` hooks.
+#' A package loaded with `load_all()` can be identified with with
+#' [is_dev_package()].
 #'
 #' # Differences to regular loading
 #'

--- a/man/load_all.Rd
+++ b/man/load_all.Rd
@@ -99,6 +99,8 @@ helpers are run during package loading.
 
 \code{is_loading()} returns \code{TRUE} when it is called while \code{load_all()}
 is running. This may be useful e.g. in \code{.onLoad} hooks.
+A package loaded with \code{load_all()} can be identified with with
+\code{\link[=is_dev_package]{is_dev_package()}}.
 }
 \section{Differences to regular loading}{
 \code{load_all()} tries its best to reproduce the behaviour of


### PR DESCRIPTION
Followup to #269. 

Adds cross-reference to `is_dev_package()` from `load_all()` documentation.