### PR TITLE
Check if rstudioapi is available

### DIFF
--- a/R/dev-help.R
+++ b/R/dev-help.R
@@ -89,7 +89,7 @@ print.dev_topic <- function(x, ...) {
   type <- arg_match0(x$type %||% "text", c("text", "html"))
 
   # Use rstudio's previewRd() if possible
-  if (type == "html" && is_rstudio() && is_installed("rstudioapi")) {
+  if (type == "html" && rstudioapi_available()) {
     # If the package has Rd macros, this needs a version of rstudio
     # that loads them, see rstudio/rstudio#12111
     version_needed <- if (has_rd_macros(dirname(dirname(x$path)))) "2022.12.0.256"

--- a/R/utils.R
+++ b/R/utils.R
@@ -203,3 +203,7 @@ cat_line <- function(...) {
 is_rstudio <- function() {
   is_string(.Platform$GUI, "RStudio")
 }
+
+rstudioapi_available <- function() {
+  is_installed("rstudioapi") && rstudioapi::isAvailable()
+}


### PR DESCRIPTION
In terms of guarding calls to `rstudioapi::hasFun()` and `rstudioapi::callFun()`, it seems more appropriate to use `rstudioapi::isAvailable()` than to directly consult `.Platform$GUI`. This is what we do in usethis, for example:

https://github.com/r-lib/usethis/blob/9e64daf13ac1636187d59e6446d9526a414d8ba6/R/rstudio.R#L129-L131

I didn't replace `is_rstudio()` wholesale because it's possible that the remaining uses really do need to consult `.Platform$GUI`.