### PR TITLE
Add a link to parse failure location to `load_all()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pkgload (development version)
 
+* `load_all()` now includes a link to the exact location when loading failed (@olivroy, #282).
+
 * Fixed an error when updating packages on load (@olivroy, #261).
 
 * Fixed a bug in `shim_help()` where a complex `package = ` argument

--- a/R/source.R
+++ b/R/source.R
@@ -13,7 +13,7 @@ source_many <- function(files, encoding = "UTF-8", envir = parent.frame()) {
       source_one(file, encoding, envir = envir),
       error = function(cnd) {
         path <- file.path(basename(dirname(file)), basename(file))
-        is_parse_error <- tryCatch(identical(as.character(cnd$call[1]), "parse"), error = function(e) FALSE)
+        is_parse_error <- is_call(cnd$call, "parse")
 
         if (is_parse_error) {
           # Tweak base message to be shorter and add link to src location.

--- a/R/source.R
+++ b/R/source.R
@@ -13,7 +13,33 @@ source_many <- function(files, encoding = "UTF-8", envir = parent.frame()) {
       source_one(file, encoding, envir = envir),
       error = function(cnd) {
         path <- file.path(basename(dirname(file)), basename(file))
-        msg <- paste0("Failed to load {.file {path}}")
+        is_parse_error <- identical(as.character(cnd$call[1]), "parse")
+
+        if (is_parse_error) {
+          # Tweak base message to be shorter and add link to src location.
+          location <- conditionMessage(cnd)
+          # extract :<line>:<col> in base message.
+          line_col <- regmatches(location, m = regexpr("\\:\\d+\\:\\d+", location))
+          if (length(line_col) > 0) {
+            # Tweak parent message.
+            path_show <- paste0(path, line_col)
+            # tweak parse() message to include an hyperlink.
+            # Replace full path by relative path + hyperlink
+            path_hyperlink <- cli::format_inline(paste0("At {.file ", path_show, "}:"))
+
+            cnd$message <- sub(
+              paste0("^.+", path_show, "\\:"),
+              path_hyperlink,
+              cnd$message
+            )
+            # only need for basename in pkgload message, since hyperlink
+            # is now included in parent message
+            msg <- paste0("Failed to load {.val {basename(path)}}")
+
+          }
+        } else {
+          msg <- paste0("Failed to load {.file {path}}")
+        }
         cli::cli_abort(msg, parent = cnd, call = quote(load_all()))
       }
     )

--- a/R/source.R
+++ b/R/source.R
@@ -28,7 +28,7 @@ source_many <- function(files, encoding = "UTF-8", envir = parent.frame()) {
             path_hyperlink <- cli::format_inline(paste0("At {.file ", path_show, "}:"))
 
             cnd$message <- sub(
-              paste0("^.+", path_show, "\\:"),
+              paste0("^.*", path_show, "\\:"),
               path_hyperlink,
               cnd$message
             )

--- a/R/source.R
+++ b/R/source.R
@@ -11,39 +11,10 @@ source_many <- function(files, encoding = "UTF-8", envir = parent.frame()) {
   for (file in files) {
     try_fetch(
       source_one(file, encoding, envir = envir),
-      error = function(cnd) {
-        path <- file.path(basename(dirname(file)), basename(file))
-        is_parse_error <- is_call(cnd$call, "parse")
-
-        if (is_parse_error) {
-          # Tweak base message to be shorter and add link to src location.
-          location <- conditionMessage(cnd)
-          # extract :<line>:<col> in base message.
-          line_col <- regmatches(location, m = regexpr("\\:\\d+\\:\\d+", location))
-          if (length(line_col) > 0) {
-            # Tweak parent message.
-            path_show <- paste0(path, line_col)
-            # tweak parse() message to include an hyperlink.
-            # Replace full path by relative path + hyperlink
-            path_hyperlink <- cli::format_inline(paste0("At {.file ", path_show, "}:"))
-
-            cnd$message <- sub(
-              paste0("^.*", path_show, "\\:"),
-              path_hyperlink,
-              cnd$message
-            )
-            # only need for basename in pkgload message, since hyperlink
-            # is now included in parent message
-            msg <- paste0("Failed to load {.val {basename(path)}}")
-
-          }
-        } else {
-          msg <- paste0("Failed to load {.file {path}}")
-        }
-        cli::cli_abort(msg, parent = cnd, call = quote(load_all()))
-      }
+      error = function(cnd) handle_source_error(cnd, file)
     )
   }
+
   invisible()
 }
 
@@ -52,15 +23,49 @@ source_one <- function(file, encoding, envir = parent.frame()) {
   stopifnot(is.environment(envir))
 
   lines <- read_lines_enc(file, file_encoding = encoding)
-  srcfile <- srcfilecopy(file, lines, file.info(file)[1, "mtime"],
-    isFile = TRUE)
-  exprs <- parse(text = lines, n = -1, srcfile = srcfile)
+  srcfile <- srcfilecopy(file, lines, file.info(file)[1, "mtime"], isFile = TRUE)
 
-  n <- length(exprs)
-  if (n == 0L) return(invisible())
+  withCallingHandlers(
+    exprs <- parse(text = lines, n = -1, srcfile = srcfile),
+    error = function(cnd) handle_parse_error(cnd, file)
+  )
 
-  for (i in seq_len(n)) {
-    eval(exprs[i], envir)
+  for (expr in exprs) {
+    eval(expr, envir)
   }
+
   invisible()
+}
+
+handle_source_error <- function(cnd, file) {
+  path <- file.path(basename(dirname(file)), basename(file))
+  msg <- paste0("Failed to load {.file {path}}")
+  cli::cli_abort(msg, parent = cnd, call = quote(load_all()))
+}
+
+handle_parse_error <- function(cnd, file) {
+  path <- file.path(basename(dirname(file)), basename(file))
+
+  # Tweak base message to be shorter and add link to src location.
+  msg <- conditionMessage(cnd)
+
+  # Extract :<line>:<col> in base message.
+  location <- regmatches(msg, m = regexpr("\\:\\d+\\:\\d+", msg))
+
+  if (length(location) == 0) {
+    return(zap())
+  }
+
+  suffixed_path <- paste0(path, location)
+
+  # Tweak parse() message to include an hyperlink.
+  # Replace full path by relative path + hyperlink
+  path_hyperlink <- cli::format_inline(paste0("At {.file ", suffixed_path, "}:"))
+  msg <- sub(
+    paste0("^.*", suffixed_path, "\\:"),
+    path_hyperlink,
+    msg
+  )
+
+  abort(msg, call = conditionCall(cnd))
 }

--- a/R/source.R
+++ b/R/source.R
@@ -13,7 +13,7 @@ source_many <- function(files, encoding = "UTF-8", envir = parent.frame()) {
       source_one(file, encoding, envir = envir),
       error = function(cnd) {
         path <- file.path(basename(dirname(file)), basename(file))
-        is_parse_error <- identical(as.character(cnd$call[1]), "parse")
+        is_parse_error <- tryCatch(identical(as.character(cnd$call[1]), "parse"), error = function(e) FALSE)
 
         if (is_parse_error) {
           # Tweak base message to be shorter and add link to src location.

--- a/tests/testthat/_snaps/source.md
+++ b/tests/testthat/_snaps/source.md
@@ -4,7 +4,7 @@
       source_many(test_path("testSource", c("a.R", "b.R")))
     Condition
       Error in `load_all()`:
-      ! Failed to load 'testSource/b.R'
+      ! Failed to load "b.R"
       Caused by error in `parse()`:
       ! testSource/b.R:2:0: unexpected end of input
       1: b <-

--- a/tests/testthat/_snaps/source.md
+++ b/tests/testthat/_snaps/source.md
@@ -6,7 +6,7 @@
       Error in `load_all()`:
       ! Failed to load "b.R"
       Caused by error in `parse()`:
-      ! testSource/b.R:2:0: unexpected end of input
+      ! At 'testSource/b.R:2:0': unexpected end of input
       1: b <-
          ^
 

--- a/tests/testthat/_snaps/source.md
+++ b/tests/testthat/_snaps/source.md
@@ -4,7 +4,7 @@
       source_many(test_path("testSource", c("a.R", "b.R")))
     Condition
       Error in `load_all()`:
-      ! Failed to load "b.R"
+      ! Failed to load 'testSource/b.R'
       Caused by error in `parse()`:
       ! At 'testSource/b.R:2:0': unexpected end of input
       1: b <-


### PR DESCRIPTION
Currently, the message when `load_all()` fails contains too much information. It is also inefficient to navigate to the culprit line manually when cli offers a way to do this.

This PR suggests to rethrow the message created by `parse()` to include a clickable hyperlink.

So that the full path doesn't get printed.

* Also get a clickable link to the exact failure location.

Before:
![image](https://github.com/r-lib/pkgload/assets/52606734/902d09c7-7e2c-4806-bab8-2604590c08e1)

This PR:
![image](https://github.com/r-lib/pkgload/assets/52606734/e3fdb4e9-7d68-4ef7-9f39-d99aae1386b8)

I also verified that this works when using pkgload with a path that is not `"."` and the link works perfectly!

I have modified `traceback()` in my .Rprofile to do just that, and it works really well! https://fosstodon.org/@olivroy/112441527899383725

## Considerations

* Only try to do this when the culprit is `parse()`. I don't know if other cases are possible. I will happily remove this condition if it is redundant.
* Would be broken if `parse()` changed the way it does things (i.e. if the filename was not the first thing in the error message). However, regular CI should catch that pretty easily in advance and adjustments to pkgload could be made before the release of a new version of R.
* I added an `"At"` before the path (for readability). I like it, but it may not fit well with internationalization. Also, does R support right to left text rendering, it may not work as expected in this case. I may remove the `"At"`

![image](https://github.com/r-lib/pkgload/assets/52606734/b14148f0-f777-4a49-a8a0-5b506a3f4cba)

Note that I have been using pkgload with this PR for the past 2 weeks, and it is a significant speed improvement to my (careless) workflow to fix issues faster.
