### PR TITLE
Upkeep - drop crayon, drop mockr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Suggests:
     Rcpp,
     remotes,
     rstudioapi,
-    testthat (>= 3.1.0)
+    testthat (>= 3.2.1.1)
 Config/Needs/website: tidyverse/tidytemplate, ggplot2
 Config/testthat/edition: 3
 Config/testthat/parallel: TRUE

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,9 +31,7 @@ Imports:
     withr (>= 2.4.3)
 Suggests: 
     bitops,
-    covr,
     mathjaxr,
-    mockr,
     pak,
     Rcpp,
     remotes,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,4 +43,4 @@ Config/testthat/parallel: TRUE
 Config/testthat/start-first: dll
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,6 @@ Depends:
     R (>= 3.4.0)
 Imports: 
     cli (>= 3.3.0),
-    crayon,
     desc,
     fs,
     glue,

--- a/R/load.R
+++ b/R/load.R
@@ -291,7 +291,7 @@ warn_if_conflicts <- function(package, env1, env2) {
   }
 
   header <- cli::rule(
-    left = crayon::bold("Conflicts"),
+    left = cli::style_bold("Conflicts"),
     right = paste0(package, " ", "conflicts")
   )
 
@@ -303,7 +303,7 @@ warn_if_conflicts <- function(package, env1, env2) {
 
   directions <- c(
     "i" = cli::col_silver("Did you accidentally source a file rather than using `load_all()`?"),
-    " " = cli::col_silver(glue::glue("Run {run_rm} to remove the conflicts."))
+    " " = cli::col_silver("Run {run_rm} to remove the conflicts.")
   )
 
   cli::cli_warn(
@@ -333,7 +333,7 @@ conflict_bullets <- function(package, both) {
     more <- NULL
   }
 
-  bullets <- glue::glue("`{crayon::green(both)}` masks `{crayon::blue(package)}::{both}()`.")
+  bullets <- glue::glue("`{cli::col_green(both)}` masks `{cli::col_blue(package)}::{both}()`.")
   c(set_names(bullets, "x"), more)
 }
 

--- a/tests/testthat/helper-pkgload.R
+++ b/tests/testthat/helper-pkgload.R
@@ -2,13 +2,6 @@ local_load_all_quiet <- function(value = TRUE, frame = caller_env()) {
   local_options("testthat:::load_all_quiet_default" = value, .frame = frame)
 }
 
-expect_no_warning <- function(object) {
-  expect_warning({{ object }}, NA)
-}
-expect_no_message <- function(object) {
-  expect_message({{ object }}, NA)
-}
-
 suppress_output <- function(expr) {
   capture.output(
     capture.output(

--- a/tests/testthat/test-dll.R
+++ b/tests/testthat/test-dll.R
@@ -48,6 +48,7 @@ test_that("load_all() compiles and loads DLLs", {
 
   # DLL should be listed in .dynLibs()
   dynlibs <- vapply(.dynLibs(), `[[`, "name", FUN.VALUE = character(1))
+  expect_match(dynlibs, "TestDllLoad", all = FALSE)
   pkgbuild::clean_dll("testDllLoad")
 
   unload("testDllLoad")

--- a/tests/testthat/test-dll.R
+++ b/tests/testthat/test-dll.R
@@ -48,7 +48,7 @@ test_that("load_all() compiles and loads DLLs", {
 
   # DLL should be listed in .dynLibs()
   dynlibs <- vapply(.dynLibs(), `[[`, "name", FUN.VALUE = character(1))
-  expect_match(dynlibs, "TestDllLoad", all = FALSE)
+  expect_match(dynlibs, "testDllLoad", all = FALSE)
   pkgbuild::clean_dll("testDllLoad")
 
   unload("testDllLoad")

--- a/tests/testthat/test-dll.R
+++ b/tests/testthat/test-dll.R
@@ -18,18 +18,17 @@ test_that("unload() unloads DLLs from packages loaded with library()", {
 
   # Check that it's loaded properly, by running a function from the package.
   # nulltest() calls a C function which returns null.
-  expect_true(is.null(nulltest()))
+  expect_null(nulltest())
 
   # DLL should be listed in .dynLibs()
   dynlibs <- vapply(.dynLibs(), `[[`, "name", FUN.VALUE = character(1))
-  expect_true(any(grepl("testDllLoad", dynlibs)))
+  expect_match(dynlibs, "testDllLoad", all = FALSE)
 
   unload("testDllLoad")
 
   # DLL should not be listed in .dynLibs()
   dynlibs <- vapply(.dynLibs(), `[[`, "name", FUN.VALUE = character(1))
-  expect_false(any(grepl("testDllLoad", dynlibs)))
-
+  expect_no_match(dynlibs, "testDllLoad")
 
 
   # Clean out compiled objects
@@ -45,32 +44,32 @@ test_that("load_all() compiles and loads DLLs", {
 
   # Check that it's loaded properly, by running a function from the package.
   # nulltest() calls a C function which returns null.
-  expect_true(is.null(nulltest()))
+  expect_null(nulltest())
 
   # DLL should be listed in .dynLibs()
   dynlibs <- vapply(.dynLibs(), `[[`, "name", FUN.VALUE = character(1))
-  expect_true(any(grepl("testDllLoad", dynlibs)))
+  pkgbuild::clean_dll("testDllLoad")
 
   unload("testDllLoad")
 
   # DLL should not be listed in .dynLibs()
   dynlibs <- vapply(.dynLibs(), `[[`, "name", FUN.VALUE = character(1))
-  expect_false(any(grepl("testDllLoad", dynlibs)))
+  expect_no_match(dynlibs, "testDllLoad")
 
 
   # Loading again, and reloading
   # Should not re-compile (don't have a proper test for this)
   load_all("testDllLoad", quiet = TRUE)
-  expect_true(is.null(nulltest()))
+  expect_null(nulltest())
 
   # load_all when already loaded
   # Should not re-compile (don't have a proper test for this)
   load_all("testDllLoad", quiet = TRUE)
-  expect_true(is.null(nulltest()))
+  expect_null(nulltest())
 
   # Should re-compile (don't have a proper test for this)
   load_all("testDllLoad", recompile = TRUE, quiet = TRUE)
-  expect_true(is.null(nulltest()))
+  expect_null(nulltest())
   unload("testDllLoad")
 
   # Clean out compiled objects
@@ -83,13 +82,13 @@ test_that("Specific functions from DLLs listed in NAMESPACE can be called", {
 
   # nulltest() uses the calling convention:
   # .Call("null_test", PACKAGE = "testDllLoad")
-  expect_true(is.null(nulltest()))
+  expect_null(nulltest())
 
   # nulltest2() uses a specific C function listed in NAMESPACE, null_test2
   # null_test2 is an object in the packg_env
   # It uses this calling convention:
   # .Call(null_test2)
-  expect_true(is.null(nulltest2()))
+  expect_null(nulltest2())
   nt2 <- ns_env("testDllLoad")$null_test2
   expect_s3_class(nt2, "NativeSymbolInfo")
   expect_equal(nt2$name, "null_test2")
@@ -109,7 +108,7 @@ test_that("load_all() can compile and load DLLs linked to Rcpp", {
 
   # Check that it's loaded properly by calling the hello world function
   # which returns a list
-  expect_true(is.list(rcpp_hello_world()))
+  expect_type(rcpp_hello_world(), "list")
 
   # Check whether attribute compilation occurred and that exported
   # names are available from load_all

--- a/tests/testthat/test-help.R
+++ b/tests/testthat/test-help.R
@@ -154,8 +154,8 @@ test_that("can use macros in other packages (#120)", {
   text_lines <- topic_lines(topic, "text")
   html_lines <- topic_lines(topic, "html")
 
-  expect_true(any(grepl("foreign macro success", text_lines)))
-  expect_true(any(grepl("foreign macro.*success", html_lines)))
+  expect_match(text_lines, "foreign macro success", all = FALSE)
+  expect_match(html_lines, "foreign macro.*success", all = FALSE)
 })
 
 test_that("httpdPort() is available", {

--- a/tests/testthat/test-help.R
+++ b/tests/testthat/test-help.R
@@ -113,7 +113,7 @@ test_that("dev_help works with package and function help with the same name", {
 })
 
 test_that("dev_help gives clear error if no packages loaded", {
-  mockr::local_mock(dev_packages = function() character())
+  local_mocked_bindings(dev_packages = function() character())
   expect_snapshot(dev_help("foo"), error = TRUE)
 })
 

--- a/tests/testthat/test-load.R
+++ b/tests/testthat/test-load.R
@@ -36,7 +36,7 @@ test_that("warn_if_conflicts warns for conflicts and both objects are functions"
   e2$bar <- function() "bar"
 
   # no warning if no conflicts
-  expect_warning(warn_if_conflicts("pkg", e1, e2), NA)
+  expect_no_warning(warn_if_conflicts("pkg", e1, e2))
 
   e2$foo <- function() "foo2"
 
@@ -53,7 +53,7 @@ test_that("warn_if_conflicts does not warn for conflicts when one of the objects
   e1$foo <- function() "foo"
   e2$foo <- "foo"
 
-  expect_warning(warn_if_conflicts("pkg", e1, e2), NA)
+  expect_no_warning(warn_if_conflicts("pkg", e1, e2))
 })
 
 test_that("unloading or reloading forces bindings", {

--- a/tests/testthat/test-metadata.R
+++ b/tests/testthat/test-metadata.R
@@ -20,7 +20,7 @@ test_that("devtools metadata for load hooks", {
 
 
 test_that("NULL metadata for non-devtools-loaded packages", {
-  expect_true(is.null(dev_meta("stats")))
+  expect_null(dev_meta("stats"))
 })
 
 

--- a/tests/testthat/test-s4-unload.R
+++ b/tests/testthat/test-s4-unload.R
@@ -40,14 +40,14 @@ test_that("loading and reloading s4 classes", {
     expect_equal(getClassDef("BOrNull")@package, "testS4union")
 
     # Unloading shouldn't result in any errors or warnings
-    expect_warning(unload("testS4union"), NA)
+    expect_no_warning(unload("testS4union"))
 
     # Check that classes are unregistered
-    expect_true(is.null(getClassDef("A")))
-    expect_true(is.null(getClassDef("B")))
-    expect_true(is.null(getClassDef("AB")))
-    expect_true(is.null(getClassDef("AorNULL")))
-    expect_true(is.null(getClassDef("BorNULL")))
+    expect_null(getClassDef("A"))
+    expect_null(getClassDef("B"))
+    expect_null(getClassDef("AB"))
+    expect_null(getClassDef("AorNULL"))
+    expect_null(getClassDef("BorNULL"))
   }
 
   load_all("testS4union")
@@ -67,7 +67,7 @@ test_that("loading and reloading s4 classes", {
   })
 
   # Loading again shouldn't result in any errors or warnings
-  expect_warning(load_all("testS4union", reset = FALSE), NA)
+  expect_no_warning(load_all("testS4union", reset = FALSE) )
 
   unload("testS4union")
   unloadNamespace("stats4")   # This was imported by testS4union
@@ -75,7 +75,7 @@ test_that("loading and reloading s4 classes", {
   # Check that classes are unregistered
   # This test on A fails for some bizarre reason - bug in R? But it doesn't
   # to cause any practical problems.
-  expect_true(is.null(getClassDef("A")))
-  expect_true(is.null(getClassDef("B")))
-  expect_true(is.null(getClassDef("AB")))
+  expect_null(getClassDef("A"))
+  expect_null(getClassDef("B"))
+  expect_null(getClassDef("AB"))
 })

--- a/tests/testthat/test-shim.R
+++ b/tests/testthat/test-shim.R
@@ -183,7 +183,7 @@ test_that("shim_library.dynam loads compiled dll/so from inst/src/", {
 
   # Check that it's loaded properly, by running a function from the package.
   # nulltest3() calls a C function which returns null.
-  expect_true(is.null(nulltest3()))
+  expect_null(nulltest3())
 
   # Clean out compiled objects
   pkgbuild::clean_dll("testLibDynam")


### PR DESCRIPTION
* Drop crayon 
* Drop mockr to use `local_mocked_bindings()`
* Remove home-grown `expect_no_warning()`
* Test lints (`expect_null()`, `expect_match()`, etc.

Conflicts still print as expected

![image](https://github.com/r-lib/pkgload/assets/52606734/c53ebf2d-877b-41f2-878c-428a9638d8a5)
