### PR TITLE
Generate compilation database on load

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,6 +31,7 @@ Imports:
     withr (>= 2.4.3)
 Suggests: 
     bitops,
+    jsonlite,
     mathjaxr,
     pak,
     Rcpp,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,7 @@ Imports:
     glue,
     methods,
     pkgbuild,
+    processx,
     rlang (>= 1.1.1),
     rprojroot,
     utils,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,8 @@ Suggests:
     Rcpp,
     remotes,
     rstudioapi,
-    testthat (>= 3.2.1.1)
+    testthat (>= 3.2.1.1),
+    usethis
 Config/Needs/website: tidyverse/tidytemplate, ggplot2
 Config/testthat/edition: 3
 Config/testthat/parallel: TRUE

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@
   Config/devtools/compilation-database: true
   ```
 
-  You'll also want to add `compile_commands.json` to your gitignoe and
+  You'll also want to add `compile_commands.json` to your gitignore and
   Rbuildignore files.
 
 * `load_all()` now includes a link to the exact location when loading failed (@olivroy, #282).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,19 @@
 # pkgload (development version)
 
-* `load_all()` now includes a link to the exact location when loading failed (@olivroy, #282).
+* New experimental feature for generating a `compile_commands.json` file after
+  each `load_all()`. This file is used by LSP servers such as clangd to provide
+  intellisense features in your native files. To enable it, add this directive
+  to your `DESCRIPTION` file:
 
+  ```
+  Config/devtools/compilation-database: true
+  ```
+
+  You'll also want to add `compile_commands.json` to your gitignoe and
+  Rbuildignore files.
+
+* `load_all()` now includes a link to the exact location when loading failed (@olivroy, #282).
+  
 * User onload hooks are now passed a library path.
 
 * Fixed an error when updating packages on load (@olivroy, #261).

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,10 @@
   You'll also want to add `compile_commands.json` and `.cache` to your gitignore
   and Rbuildignore files.
 
+  To accomplish all these steps, feel free to use the unexported function
+  `pkgload:::use_compilation_db()`. It will eventually be exported from the
+  usethis package.
+
 * `load_all()` now includes a link to the exact location when loading failed (@olivroy, #282).
   
 * User onload hooks are now passed a library path.

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
   to your `DESCRIPTION` file:
 
   ```
-  Config/devtools/compilation-database: true
+  Config/build/compilation-database: true
   ```
 
   You'll also want to add `compile_commands.json` to your gitignore and

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,8 +9,8 @@
   Config/build/compilation-database: true
   ```
 
-  You'll also want to add `compile_commands.json` to your gitignore and
-  Rbuildignore files.
+  You'll also want to add `compile_commands.json` and `.cache` to your gitignore
+  and Rbuildignore files.
 
 * `load_all()` now includes a link to the exact location when loading failed (@olivroy, #282).
   

--- a/R/compilation-db.R
+++ b/R/compilation-db.R
@@ -127,7 +127,7 @@ build_commands <- function(src_path, package, files, desc) {
   out <- rcmd(
     wd = src_path,
     env = c(CLINK_CPPFLAGS = linking_to_flags),
-    "shlib",
+    "SHLIB",
     c(
       "--dry-run",
       "-o", paste0(package, ".so"),

--- a/R/compilation-db.R
+++ b/R/compilation-db.R
@@ -33,6 +33,18 @@ generate_db <- function(path = ".") {
   invisible(json)
 }
 
+has_compilation_db <- function(desc) {
+  field <- toupper(desc$get_field(
+    "Config/devtools/compilation-database",
+    default = FALSE
+  ))
+
+  out <- as.logical(field)
+  check_bool(out, arg = "Config/devtools/compilation-database")
+  
+  out
+}
+
 build_files <- function(src_path) {
   makevars <- makevars_file(src_path)
   has_objects <- !is.null(makevars) && any(grepl("^OBJECTS *=", readLines(makevars)))

--- a/R/compilation-db.R
+++ b/R/compilation-db.R
@@ -40,12 +40,12 @@ generate_db <- function(path = ".") {
 
 has_compilation_db <- function(desc) {
   field <- toupper(desc$get_field(
-    "Config/devtools/compilation-database",
+    "Config/build/compilation-database",
     default = FALSE
   ))
 
   out <- as.logical(field)
-  check_bool(out, arg = "Config/devtools/compilation-database")
+  check_bool(out, arg = "Config/build/compilation-database")
   
   out
 }

--- a/R/compilation-db.R
+++ b/R/compilation-db.R
@@ -1,7 +1,19 @@
 # Should these tools move to pkgbuild?
 
+use_compilation_db <- function() {
+  check_installed("usethis")
+
+  # Sneaky import won't be necessary once in usethis
+  proj_desc_field_update <- env_get(ns_env("usethis"), "proj_desc_field_update")
+  proj_desc_field_update("Config/build/compilation-database", "true")
+
+  files <- c("compile_commands.json", ".cache")
+  usethis::use_git_ignore(files)
+  usethis::use_build_ignore(files)
+}
+
 generate_db <- function(path = ".") {
-  rlang::check_installed("jsonlite")
+  check_installed("jsonlite")
 
   path <- pkg_path(path)
   package <- pkg_name(path)

--- a/R/compilation-db.R
+++ b/R/compilation-db.R
@@ -233,7 +233,7 @@ linking_to_flags <- function(desc) {
   linking_to <- desc$get_field("LinkingTo", default = NULL)
 
   if (is.null(linking_to)) {
-    return(character())
+    return("")
   }
 
   # Split by comma

--- a/R/compilation-db.R
+++ b/R/compilation-db.R
@@ -1,0 +1,141 @@
+# Should these tools move to pkgbuild?
+
+generate_db <- function(path = ".") {
+  rlang::check_installed("jsonlite")
+
+  path <- pkg_path(path)
+  package <- pkg_name(path)
+
+  src_path <- fs::path(path, "src")
+
+  if (!fs::dir_exists(src_path)) {
+    return(invisible(NULL))
+  }
+
+  files <- build_files(src_path)
+  commands <- build_commands(src_path, package, files)
+  directives <- Map(
+    cmd = commands,
+    file = files,
+    dir = src_path,
+    as_json_directive
+  )
+
+  json <- jsonlite::toJSON(unname(directives))
+  json <- jsonlite::prettify(json)
+
+  writeLines(
+    json,
+    fs::path(path, "compile_commands.json"),
+    useBytes = TRUE
+  )
+
+  invisible(json)
+}
+
+build_files <- function(src_path) {
+  makevars <- makevars_file(src_path)
+  has_objects <- !is.null(makevars) && any(grepl("^OBJECTS *=", readLines(makevars)))
+
+  if (has_objects) {
+    files <- stop("todo")
+  } else {
+    # Same pattern as in `R CMD shlib`
+    files <- dir(src_path, pattern = "\\.([cfmM]|cc|cpp|f90|f95|mm)$", all.files = TRUE)
+  }
+
+  files
+}
+
+build_commands <- function(src_path, package, files) {
+  rcmd <- function(...) {
+    out <- pkgbuild::rcmd_build_tools(..., quiet = TRUE)
+
+    if (out$status != 0) {
+      abort(c("Can't generate compilation database.", out$stderr))
+    }
+
+    out$stdout
+  }
+
+  out <- rcmd(
+    wd = src_path,
+    "shlib",
+    c(
+      "--dry-run",
+      "-o", paste0(package, ".so"),
+      # Inject `--always-make` in make arguments to force full dry-run
+      # See https://github.com/rstudio/rstudio/pull/11917
+      "' --always-make IGNORED='",
+      files
+    )
+  )
+  out <- strsplit(out, "\n")[[1]]
+
+  cc <- rcmd(
+    wd = src_path,
+    "config",
+    "CC"
+  )
+  stopifnot(is_string(cc), nchar(cc) > 1)
+
+  # Remove trailing newline
+  cc <- substr(cc, 1, nchar(cc) - 1);
+
+  # Remove any line that doesn't look like a compilation command. Note that
+  # removing the header and footer is not sufficient, some other build commands
+  # might be interspersed in some cases, e.g. with rlang.
+  commands <- out[startsWith(out, cc)]
+
+  if (length(commands) != length(files)) {
+    abort(
+      "Expected same number of compilation commands as object files",
+      .internal = TRUE
+    )
+  }
+
+  commands
+}
+
+as_json_directive <- function(cmd, file, dir) {
+  if (!grepl(file, cmd, fixed = TRUE)) {
+    abort(
+      "Compilation command doesn't match object file",
+      .internal = TRUE
+    )
+  }
+
+  list(
+    command = jsonlite::unbox(cmd),
+    file = jsonlite::unbox(file),
+    directory = jsonlite::unbox(dir)
+  )
+}
+
+makevars_file <- function(src_path) {
+  if (is_windows()) {
+    if (Sys.getenv("R_ARCH") == "/x64") {
+      file <- fs::path(src_path, "Makevars.ucrt")
+      if (fs::file_exists(file)) {
+        return(file)
+      }
+
+      file <- fs::path(src_path, "Makevars.win64")
+      if (fs::file_exists(file)) {
+        return(file)
+      }
+    }
+
+    file <- fs::path(src_path, "Makevars.win")
+    if (fs::file_exists(file)) {
+      return(file)
+    }
+  }
+
+  file <- fs::path(src_path, "Makevars")
+  if (fs::file_exists(file)) {
+    return(file)
+  }
+
+  NULL
+}

--- a/R/compilation-db.R
+++ b/R/compilation-db.R
@@ -124,13 +124,19 @@ build_commands <- function(src_path, package, files, desc) {
   # inject these manually
   linking_to_flags <- linking_to_flags(desc)
 
+  if (is_windows()) {
+    ext <- ".dll"
+  } else {
+    ext <- ".so"
+  }
+
   out <- rcmd(
     wd = src_path,
     env = c(CLINK_CPPFLAGS = linking_to_flags),
     "SHLIB",
     c(
       "--dry-run",
-      "-o", paste0(package, ".so"),
+      "-o", paste0(package, ext),
       # Inject `--always-make` in make arguments to force full dry-run
       # See https://github.com/rstudio/rstudio/pull/11917
       sprintf("' --always-make %s IGNORED='", linking_to_flags),

--- a/R/compilation-db.R
+++ b/R/compilation-db.R
@@ -164,8 +164,14 @@ build_commands <- function(src_path, package, files, desc) {
 # `R CMD config` is quite slow so we print the variables of interest by directly
 # invoking make
 compilers <- function() {
+  if (is_windows()) {
+    system_makeconf <- fs::path(R.home(), "etc", .Platform$r_arch, "Makeconf")
+  } else {
+    system_makeconf <- fs::path(R.home(), "etc", "Makeconf")
+  }
+
   makevars <- c(
-    fs::path(R.home(), "etc", "Makeconf"),
+    system_makeconf,
     tools::makevars_site(),
     tools::makevars_user(),
     system.file("print-var.mk", package = "pkgload")

--- a/R/compilation-db.R
+++ b/R/compilation-db.R
@@ -24,9 +24,13 @@ generate_db <- function(path = ".") {
   json <- jsonlite::toJSON(unname(directives))
   json <- jsonlite::prettify(json)
 
+  # We want a pretty file with a single trailing newline
+  json <- sub("\n*$", "\n", json)
+
   writeLines(
     json,
     fs::path(path, "compile_commands.json"),
+    sep = "",
     useBytes = TRUE
   )
 

--- a/R/import-standalone-obj-type.R
+++ b/R/import-standalone-obj-type.R
@@ -1,0 +1,360 @@
+# Standalone file: do not edit by hand
+# Source: <https://github.com/r-lib/rlang/blob/main/R/standalone-obj-type.R>
+# ----------------------------------------------------------------------
+#
+# ---
+# repo: r-lib/rlang
+# file: standalone-obj-type.R
+# last-updated: 2023-05-01
+# license: https://unlicense.org
+# imports: rlang (>= 1.1.0)
+# ---
+#
+# ## Changelog
+#
+# 2023-05-01:
+# - `obj_type_friendly()` now only displays the first class of S3 objects.
+#
+# 2023-03-30:
+# - `stop_input_type()` now handles `I()` input literally in `arg`.
+#
+# 2022-10-04:
+# - `obj_type_friendly(value = TRUE)` now shows numeric scalars
+#   literally.
+# - `stop_friendly_type()` now takes `show_value`, passed to
+#   `obj_type_friendly()` as the `value` argument.
+#
+# 2022-10-03:
+# - Added `allow_na` and `allow_null` arguments.
+# - `NULL` is now backticked.
+# - Better friendly type for infinities and `NaN`.
+#
+# 2022-09-16:
+# - Unprefixed usage of rlang functions with `rlang::` to
+#   avoid onLoad issues when called from rlang (#1482).
+#
+# 2022-08-11:
+# - Prefixed usage of rlang functions with `rlang::`.
+#
+# 2022-06-22:
+# - `friendly_type_of()` is now `obj_type_friendly()`.
+# - Added `obj_type_oo()`.
+#
+# 2021-12-20:
+# - Added support for scalar values and empty vectors.
+# - Added `stop_input_type()`
+#
+# 2021-06-30:
+# - Added support for missing arguments.
+#
+# 2021-04-19:
+# - Added support for matrices and arrays (#141).
+# - Added documentation.
+# - Added changelog.
+#
+# nocov start
+
+#' Return English-friendly type
+#' @param x Any R object.
+#' @param value Whether to describe the value of `x`. Special values
+#'   like `NA` or `""` are always described.
+#' @param length Whether to mention the length of vectors and lists.
+#' @return A string describing the type. Starts with an indefinite
+#'   article, e.g. "an integer vector".
+#' @noRd
+obj_type_friendly <- function(x, value = TRUE) {
+  if (is_missing(x)) {
+    return("absent")
+  }
+
+  if (is.object(x)) {
+    if (inherits(x, "quosure")) {
+      type <- "quosure"
+    } else {
+      type <- class(x)[[1L]]
+    }
+    return(sprintf("a <%s> object", type))
+  }
+
+  if (!is_vector(x)) {
+    return(.rlang_as_friendly_type(typeof(x)))
+  }
+
+  n_dim <- length(dim(x))
+
+  if (!n_dim) {
+    if (!is_list(x) && length(x) == 1) {
+      if (is_na(x)) {
+        return(switch(
+          typeof(x),
+          logical = "`NA`",
+          integer = "an integer `NA`",
+          double =
+            if (is.nan(x)) {
+              "`NaN`"
+            } else {
+              "a numeric `NA`"
+            },
+          complex = "a complex `NA`",
+          character = "a character `NA`",
+          .rlang_stop_unexpected_typeof(x)
+        ))
+      }
+
+      show_infinites <- function(x) {
+        if (x > 0) {
+          "`Inf`"
+        } else {
+          "`-Inf`"
+        }
+      }
+      str_encode <- function(x, width = 30, ...) {
+        if (nchar(x) > width) {
+          x <- substr(x, 1, width - 3)
+          x <- paste0(x, "...")
+        }
+        encodeString(x, ...)
+      }
+
+      if (value) {
+        if (is.numeric(x) && is.infinite(x)) {
+          return(show_infinites(x))
+        }
+
+        if (is.numeric(x) || is.complex(x)) {
+          number <- as.character(round(x, 2))
+          what <- if (is.complex(x)) "the complex number" else "the number"
+          return(paste(what, number))
+        }
+
+        return(switch(
+          typeof(x),
+          logical = if (x) "`TRUE`" else "`FALSE`",
+          character = {
+            what <- if (nzchar(x)) "the string" else "the empty string"
+            paste(what, str_encode(x, quote = "\""))
+          },
+          raw = paste("the raw value", as.character(x)),
+          .rlang_stop_unexpected_typeof(x)
+        ))
+      }
+
+      return(switch(
+        typeof(x),
+        logical = "a logical value",
+        integer = "an integer",
+        double = if (is.infinite(x)) show_infinites(x) else "a number",
+        complex = "a complex number",
+        character = if (nzchar(x)) "a string" else "\"\"",
+        raw = "a raw value",
+        .rlang_stop_unexpected_typeof(x)
+      ))
+    }
+
+    if (length(x) == 0) {
+      return(switch(
+        typeof(x),
+        logical = "an empty logical vector",
+        integer = "an empty integer vector",
+        double = "an empty numeric vector",
+        complex = "an empty complex vector",
+        character = "an empty character vector",
+        raw = "an empty raw vector",
+        list = "an empty list",
+        .rlang_stop_unexpected_typeof(x)
+      ))
+    }
+  }
+
+  vec_type_friendly(x)
+}
+
+vec_type_friendly <- function(x, length = FALSE) {
+  if (!is_vector(x)) {
+    abort("`x` must be a vector.")
+  }
+  type <- typeof(x)
+  n_dim <- length(dim(x))
+
+  add_length <- function(type) {
+    if (length && !n_dim) {
+      paste0(type, sprintf(" of length %s", length(x)))
+    } else {
+      type
+    }
+  }
+
+  if (type == "list") {
+    if (n_dim < 2) {
+      return(add_length("a list"))
+    } else if (is.data.frame(x)) {
+      return("a data frame")
+    } else if (n_dim == 2) {
+      return("a list matrix")
+    } else {
+      return("a list array")
+    }
+  }
+
+  type <- switch(
+    type,
+    logical = "a logical %s",
+    integer = "an integer %s",
+    numeric = ,
+    double = "a double %s",
+    complex = "a complex %s",
+    character = "a character %s",
+    raw = "a raw %s",
+    type = paste0("a ", type, " %s")
+  )
+
+  if (n_dim < 2) {
+    kind <- "vector"
+  } else if (n_dim == 2) {
+    kind <- "matrix"
+  } else {
+    kind <- "array"
+  }
+  out <- sprintf(type, kind)
+
+  if (n_dim >= 2) {
+    out
+  } else {
+    add_length(out)
+  }
+}
+
+.rlang_as_friendly_type <- function(type) {
+  switch(
+    type,
+
+    list = "a list",
+
+    NULL = "`NULL`",
+    environment = "an environment",
+    externalptr = "a pointer",
+    weakref = "a weak reference",
+    S4 = "an S4 object",
+
+    name = ,
+    symbol = "a symbol",
+    language = "a call",
+    pairlist = "a pairlist node",
+    expression = "an expression vector",
+
+    char = "an internal string",
+    promise = "an internal promise",
+    ... = "an internal dots object",
+    any = "an internal `any` object",
+    bytecode = "an internal bytecode object",
+
+    primitive = ,
+    builtin = ,
+    special = "a primitive function",
+    closure = "a function",
+
+    type
+  )
+}
+
+.rlang_stop_unexpected_typeof <- function(x, call = caller_env()) {
+  abort(
+    sprintf("Unexpected type <%s>.", typeof(x)),
+    call = call
+  )
+}
+
+#' Return OO type
+#' @param x Any R object.
+#' @return One of `"bare"` (for non-OO objects), `"S3"`, `"S4"`,
+#'   `"R6"`, or `"R7"`.
+#' @noRd
+obj_type_oo <- function(x) {
+  if (!is.object(x)) {
+    return("bare")
+  }
+
+  class <- inherits(x, c("R6", "R7_object"), which = TRUE)
+
+  if (class[[1]]) {
+    "R6"
+  } else if (class[[2]]) {
+    "R7"
+  } else if (isS4(x)) {
+    "S4"
+  } else {
+    "S3"
+  }
+}
+
+#' @param x The object type which does not conform to `what`. Its
+#'   `obj_type_friendly()` is taken and mentioned in the error message.
+#' @param what The friendly expected type as a string. Can be a
+#'   character vector of expected types, in which case the error
+#'   message mentions all of them in an "or" enumeration.
+#' @param show_value Passed to `value` argument of `obj_type_friendly()`.
+#' @param ... Arguments passed to [abort()].
+#' @inheritParams args_error_context
+#' @noRd
+stop_input_type <- function(x,
+                            what,
+                            ...,
+                            allow_na = FALSE,
+                            allow_null = FALSE,
+                            show_value = TRUE,
+                            arg = caller_arg(x),
+                            call = caller_env()) {
+  # From standalone-cli.R
+  cli <- env_get_list(
+    nms = c("format_arg", "format_code"),
+    last = topenv(),
+    default = function(x) sprintf("`%s`", x),
+    inherit = TRUE
+  )
+
+  if (allow_na) {
+    what <- c(what, cli$format_code("NA"))
+  }
+  if (allow_null) {
+    what <- c(what, cli$format_code("NULL"))
+  }
+  if (length(what)) {
+    what <- oxford_comma(what)
+  }
+  if (inherits(arg, "AsIs")) {
+    format_arg <- identity
+  } else {
+    format_arg <- cli$format_arg
+  }
+
+  message <- sprintf(
+    "%s must be %s, not %s.",
+    format_arg(arg),
+    what,
+    obj_type_friendly(x, value = show_value)
+  )
+
+  abort(message, ..., call = call, arg = arg)
+}
+
+oxford_comma <- function(chr, sep = ", ", final = "or") {
+  n <- length(chr)
+
+  if (n < 2) {
+    return(chr)
+  }
+
+  head <- chr[seq_len(n - 1)]
+  last <- chr[n]
+
+  head <- paste(head, collapse = sep)
+
+  # Write a or b. But a, b, or c.
+  if (n > 2) {
+    paste0(head, sep, final, " ", last)
+  } else {
+    paste0(head, " ", final, " ", last)
+  }
+}
+
+# nocov end

--- a/R/import-standalone-types-check.R
+++ b/R/import-standalone-types-check.R
@@ -1,0 +1,538 @@
+# Standalone file: do not edit by hand
+# Source: <https://github.com/r-lib/rlang/blob/main/R/standalone-types-check.R>
+# ----------------------------------------------------------------------
+#
+# ---
+# repo: r-lib/rlang
+# file: standalone-types-check.R
+# last-updated: 2023-03-13
+# license: https://unlicense.org
+# dependencies: standalone-obj-type.R
+# imports: rlang (>= 1.1.0)
+# ---
+#
+# ## Changelog
+#
+# 2023-03-13:
+# - Improved error messages of number checkers (@teunbrand)
+# - Added `allow_infinite` argument to `check_number_whole()` (@mgirlich).
+# - Added `check_data_frame()` (@mgirlich).
+#
+# 2023-03-07:
+# - Added dependency on rlang (>= 1.1.0).
+#
+# 2023-02-15:
+# - Added `check_logical()`.
+#
+# - `check_bool()`, `check_number_whole()`, and
+#   `check_number_decimal()` are now implemented in C.
+#
+# - For efficiency, `check_number_whole()` and
+#   `check_number_decimal()` now take a `NULL` default for `min` and
+#   `max`. This makes it possible to bypass unnecessary type-checking
+#   and comparisons in the default case of no bounds checks.
+#
+# 2022-10-07:
+# - `check_number_whole()` and `_decimal()` no longer treat
+#   non-numeric types such as factors or dates as numbers.  Numeric
+#   types are detected with `is.numeric()`.
+#
+# 2022-10-04:
+# - Added `check_name()` that forbids the empty string.
+#   `check_string()` allows the empty string by default.
+#
+# 2022-09-28:
+# - Removed `what` arguments.
+# - Added `allow_na` and `allow_null` arguments.
+# - Added `allow_decimal` and `allow_infinite` arguments.
+# - Improved errors with absent arguments.
+#
+#
+# 2022-09-16:
+# - Unprefixed usage of rlang functions with `rlang::` to
+#   avoid onLoad issues when called from rlang (#1482).
+#
+# 2022-08-11:
+# - Added changelog.
+#
+# nocov start
+
+# Scalars -----------------------------------------------------------------
+
+.standalone_types_check_dot_call <- .Call
+
+check_bool <- function(x,
+                       ...,
+                       allow_na = FALSE,
+                       allow_null = FALSE,
+                       arg = caller_arg(x),
+                       call = caller_env()) {
+  if (!missing(x) && .standalone_types_check_dot_call(ffi_standalone_is_bool_1.0.7, x, allow_na, allow_null)) {
+    return(invisible(NULL))
+  }
+
+  stop_input_type(
+    x,
+    c("`TRUE`", "`FALSE`"),
+    ...,
+    allow_na = allow_na,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_string <- function(x,
+                         ...,
+                         allow_empty = TRUE,
+                         allow_na = FALSE,
+                         allow_null = FALSE,
+                         arg = caller_arg(x),
+                         call = caller_env()) {
+  if (!missing(x)) {
+    is_string <- .rlang_check_is_string(
+      x,
+      allow_empty = allow_empty,
+      allow_na = allow_na,
+      allow_null = allow_null
+    )
+    if (is_string) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a single string",
+    ...,
+    allow_na = allow_na,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+.rlang_check_is_string <- function(x,
+                                   allow_empty,
+                                   allow_na,
+                                   allow_null) {
+  if (is_string(x)) {
+    if (allow_empty || !is_string(x, "")) {
+      return(TRUE)
+    }
+  }
+
+  if (allow_null && is_null(x)) {
+    return(TRUE)
+  }
+
+  if (allow_na && (identical(x, NA) || identical(x, na_chr))) {
+    return(TRUE)
+  }
+
+  FALSE
+}
+
+check_name <- function(x,
+                       ...,
+                       allow_null = FALSE,
+                       arg = caller_arg(x),
+                       call = caller_env()) {
+  if (!missing(x)) {
+    is_string <- .rlang_check_is_string(
+      x,
+      allow_empty = FALSE,
+      allow_na = FALSE,
+      allow_null = allow_null
+    )
+    if (is_string) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a valid name",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+IS_NUMBER_true <- 0
+IS_NUMBER_false <- 1
+IS_NUMBER_oob <- 2
+
+check_number_decimal <- function(x,
+                                 ...,
+                                 min = NULL,
+                                 max = NULL,
+                                 allow_infinite = TRUE,
+                                 allow_na = FALSE,
+                                 allow_null = FALSE,
+                                 arg = caller_arg(x),
+                                 call = caller_env()) {
+  if (missing(x)) {
+    exit_code <- IS_NUMBER_false
+  } else if (0 == (exit_code <- .standalone_types_check_dot_call(
+    ffi_standalone_check_number_1.0.7,
+    x,
+    allow_decimal = TRUE,
+    min,
+    max,
+    allow_infinite,
+    allow_na,
+    allow_null
+  ))) {
+    return(invisible(NULL))
+  }
+
+  .stop_not_number(
+    x,
+    ...,
+    exit_code = exit_code,
+    allow_decimal = TRUE,
+    min = min,
+    max = max,
+    allow_na = allow_na,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_number_whole <- function(x,
+                               ...,
+                               min = NULL,
+                               max = NULL,
+                               allow_infinite = FALSE,
+                               allow_na = FALSE,
+                               allow_null = FALSE,
+                               arg = caller_arg(x),
+                               call = caller_env()) {
+  if (missing(x)) {
+    exit_code <- IS_NUMBER_false
+  } else if (0 == (exit_code <- .standalone_types_check_dot_call(
+    ffi_standalone_check_number_1.0.7,
+    x,
+    allow_decimal = FALSE,
+    min,
+    max,
+    allow_infinite,
+    allow_na,
+    allow_null
+  ))) {
+    return(invisible(NULL))
+  }
+
+  .stop_not_number(
+    x,
+    ...,
+    exit_code = exit_code,
+    allow_decimal = FALSE,
+    min = min,
+    max = max,
+    allow_na = allow_na,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+.stop_not_number <- function(x,
+                             ...,
+                             exit_code,
+                             allow_decimal,
+                             min,
+                             max,
+                             allow_na,
+                             allow_null,
+                             arg,
+                             call) {
+  if (allow_decimal) {
+    what <- "a number"
+  } else {
+    what <- "a whole number"
+  }
+
+  if (exit_code == IS_NUMBER_oob) {
+    min <- min %||% -Inf
+    max <- max %||% Inf
+
+    if (min > -Inf && max < Inf) {
+      what <- sprintf("%s between %s and %s", what, min, max)
+    } else if (x < min) {
+      what <- sprintf("%s larger than or equal to %s", what, min)
+    } else if (x > max) {
+      what <- sprintf("%s smaller than or equal to %s", what, max)
+    } else {
+      abort("Unexpected state in OOB check", .internal = TRUE)
+    }
+  }
+
+  stop_input_type(
+    x,
+    what,
+    ...,
+    allow_na = allow_na,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_symbol <- function(x,
+                         ...,
+                         allow_null = FALSE,
+                         arg = caller_arg(x),
+                         call = caller_env()) {
+  if (!missing(x)) {
+    if (is_symbol(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a symbol",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_arg <- function(x,
+                      ...,
+                      allow_null = FALSE,
+                      arg = caller_arg(x),
+                      call = caller_env()) {
+  if (!missing(x)) {
+    if (is_symbol(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "an argument name",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_call <- function(x,
+                       ...,
+                       allow_null = FALSE,
+                       arg = caller_arg(x),
+                       call = caller_env()) {
+  if (!missing(x)) {
+    if (is_call(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a defused call",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_environment <- function(x,
+                              ...,
+                              allow_null = FALSE,
+                              arg = caller_arg(x),
+                              call = caller_env()) {
+  if (!missing(x)) {
+    if (is_environment(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "an environment",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_function <- function(x,
+                           ...,
+                           allow_null = FALSE,
+                           arg = caller_arg(x),
+                           call = caller_env()) {
+  if (!missing(x)) {
+    if (is_function(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a function",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_closure <- function(x,
+                          ...,
+                          allow_null = FALSE,
+                          arg = caller_arg(x),
+                          call = caller_env()) {
+  if (!missing(x)) {
+    if (is_closure(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "an R function",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_formula <- function(x,
+                          ...,
+                          allow_null = FALSE,
+                          arg = caller_arg(x),
+                          call = caller_env()) {
+  if (!missing(x)) {
+    if (is_formula(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a formula",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+
+# Vectors -----------------------------------------------------------------
+
+check_character <- function(x,
+                            ...,
+                            allow_null = FALSE,
+                            arg = caller_arg(x),
+                            call = caller_env()) {
+  if (!missing(x)) {
+    if (is_character(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a character vector",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_logical <- function(x,
+                          ...,
+                          allow_null = FALSE,
+                          arg = caller_arg(x),
+                          call = caller_env()) {
+  if (!missing(x)) {
+    if (is_logical(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a logical vector",
+    ...,
+    allow_na = FALSE,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+check_data_frame <- function(x,
+                             ...,
+                             allow_null = FALSE,
+                             arg = caller_arg(x),
+                             call = caller_env()) {
+  if (!missing(x)) {
+    if (is.data.frame(x)) {
+      return(invisible(NULL))
+    }
+    if (allow_null && is_null(x)) {
+      return(invisible(NULL))
+    }
+  }
+
+  stop_input_type(
+    x,
+    "a data frame",
+    ...,
+    allow_null = allow_null,
+    arg = arg,
+    call = call
+  )
+}
+
+# nocov end

--- a/R/load.R
+++ b/R/load.R
@@ -256,6 +256,14 @@ load_all <- function(path = ".",
     )
   }
 
+  # Regenerate compilation database if needed. This must happen after loading
+  # the DLL to ensure that `Makevars` is up-to-date.
+  catch_and_warn(
+    if (has_compilation_db(description)) {
+      generate_db(path)
+    }
+  )
+
   invisible(out)
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -211,3 +211,10 @@ rstudioapi_available <- function() {
 is_windows <- function() {
   .Platform$OS.type == "windows"
 }
+
+catch_and_warn <- function(expr) {
+  tryCatch(
+    expr,
+    error = function(cnd) warn(function(w, ...) conditionMessage(cnd))
+  )
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -207,3 +207,7 @@ is_rstudio <- function() {
 rstudioapi_available <- function() {
   is_installed("rstudioapi") && rstudioapi::isAvailable()
 }
+
+is_windows <- function() {
+  .Platform$OS.type == "windows"
+}

--- a/inst/print-var.mk
+++ b/inst/print-var.mk
@@ -1,0 +1,11 @@
+print-%  : ; @echo $($*)
+
+print-compilers:
+	@echo $(CC)
+	@echo $(CXX)
+	@echo $(CXX14)
+	@echo $(CXX17)
+	@echo $(CXX20)
+	@echo $(CXX23)
+	@echo $(FC)
+	@echo $(OBJC)


### PR DESCRIPTION
LSPs like clangd provide intellisense features for native files but they need to know the build flags (mostly include flags) for each root file in the project (flags for included files are inferred from root files). These tools are not able to infer the flags by themselves and so require the generation of a "compilation database": https://clang.llvm.org/docs/JSONCompilationDatabase.html.

For R packages the flags are generated by `R CMD build` and depend on the package Makevars file, possibly generated from `configure`. Generating the database after a `load_all()` seems like a reasonable update point to keep track of the changing source files (which can be added or removed during development) while ensuring the presence of an up-to-date Makevars file.

There are two main approaches for the generation of a compilation database. The first is to intercept the compiler calls during an actual build to collect arguments. This is the approach used by tools like `bear` and it works great in conjunction with `R CMD build`. The other is to generate build commands, e.g. with `make --dry-run`.

@kevinushey suggested we could use the latter approach with `R CMD shlib --dry-run`. This is a nice idea because it means we don't need any external tools to create the database. This PR implements this approach. A few caveats:

- For some reason the `shlib` command does not add include flags for `LinkingTo` dependencies, so I had to inject those manually.

- In addition to `--dry-run` we need to pass `--always-make` to `make`. See https://github.com/rstudio/rstudio/pull/11917 for the motivation and the workaround reused here.

- We need to pass target source files to `shlib`. These can easily be inferred when `Makevars` does not override `OBJECTS`. When it is overridden, we need to retrieve the contents of this variable, and then match the object files to potential sources. This sometimes clashes, e.g. in igraph there are a .c and .f files that match a single object file. We just select one file in this case and ignore the others. This should not be a big deal and should be a rare occurrence.

- There could be make directives interspersed between compile commands in the dry-run output (this happens with rlang). To detect actual commands, we simply select all lines starting with a compiler command. These commands (CC, CXX, FC, etc) could be retrieved from `R CMD config` but this tool seems extremely slow. Instead we retrieve them from the makefiles manually. These commands should be in the same order as the source files passed to `shlib`. A consistency check verifies that we have as many commands as source files and that each command indeed references the corresponding source file (typically in a `-f` flag).

The compilation database is not generated by default, the user must explicitly opt in by inserting this line in their `DESCRIPTION` file:

```dcf
Config/devtools/compilation-database: true
```

In addition the `compile_commands.json` file generated at the root should be gitignored and Rbuildignored. We'll provide a usethis function to accomplish these tasks.

The tools for generating this database should probably be moved and reexported from pkgbuild in the future (cc @gaborcsardi), but I'm implementing them here as I'd like to include the feature in the next release of pkgload.

Untested on Windows but should work on Unixes. Tested on macOS with readxl, rlang, igraph, and r-tree-sitter.
Edit: now working on Windows