### PR TITLE
Remove depency on `env_unlock()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,7 @@ Imports:
     desc,
     fs,
     glue,
+    lifecycle,
     methods,
     pkgbuild,
     processx,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # pkgload (development version)
 
+* The `reset` argment of `load_all()` is no longer supported because preserving
+  the namespace requires unlocking its environment, which is no longer possible
+  in recent versions of R.
+
 * New experimental feature for generating a `compile_commands.json` file after
   each `load_all()`. This file is used by LSP servers such as clangd to provide
   intellisense features in your native files. To enable it, add this directive

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,8 +2,9 @@
 
 * The `reset` argment of `load_all()` is no longer supported because preserving
   the namespace requires unlocking its environment, which is no longer possible
-  in recent versions of R.
-
+  in recent versions of R. It should no longer be necessary as the performance
+  issues caused by resetting the namespace were resolved a while ago.
+  
 * New experimental feature for generating a `compile_commands.json` file after
   each `load_all()`. This file is used by LSP servers such as clangd to provide
   intellisense features in your native files. To enable it, add this directive

--- a/R/load.R
+++ b/R/load.R
@@ -65,11 +65,9 @@
 #'    be useful for checking for missing exports.
 #'
 #' @param path Path to a package, or within a package.
-#' @param reset clear package environment and reset file cache before loading
-#'   any pieces of the package. This largely equivalent to running
-#'   [unload()], however the old namespaces are not completely removed and no
-#'   `.onUnload()` hooks are called. Use `reset = FALSE` may be faster for
-#'   large code bases, but is a significantly less accurate approximation.
+#' @param reset `r lifecycle::badge("deprecated")` This is no longer supported
+#'   because preserving the namespace requires unlocking its environment, which
+#'   is no longer possible in recent versions of R.
 #' @param compile If `TRUE` always recompiles the package; if `NA`
 #'   recompiles if needed (as determined by [pkgbuild::needs_compile()]);
 #'   if `FALSE`, never recompiles.
@@ -106,9 +104,6 @@
 #' # Running again loads changed files
 #' load_all("./")
 #'
-#' # With reset=TRUE, unload and reload the package for a clean start
-#' load_all("./", TRUE)
-#'
 #' # With export_all=FALSE, only objects listed as exports in NAMESPACE
 #' # are exported
 #' load_all("./", export_all = FALSE)
@@ -125,6 +120,13 @@ load_all <- function(path = ".",
                      quiet = NULL,
                      recompile = FALSE,
                      warn_conflicts = TRUE) {
+  if (!isTRUE(reset)) {
+    lifecycle::deprecate_warn(
+      when = "1.3.5", 
+      what = "load_all(reset)",
+      details = "`reset = FALSE` is no longer supported."
+    )
+  }
 
   path <- pkg_path(path)
   package <- pkg_name(path)
@@ -163,31 +165,24 @@ load_all <- function(path = ".",
   }
 
   old_methods <- list()
+  clear_cache()
 
-  if (reset) {
-    clear_cache()
-
-    # Remove package from known namespaces. We don't unload it to allow
-    # safe usage of dangling references.
-    if (is_loaded(package)) {
-      patch_colon(package)
-
-      methods_env <- ns_s3_methods(package)
-      unregister(package)
-
-      # Save foreign methods after unregistering the package's own
-      # methods. We'll restore the foreign methods but let the package
-      # register its own methods again.
-      old_methods <- as.list(methods_env)
-      old_methods <- Filter(function(x) is_foreign_method(x, package), old_methods)
-    }
-  }
-
+  # Remove package from known namespaces. We don't unload it to allow
+  # safe usage of dangling references.
   if (is_loaded(package)) {
-    rlang::env_unlock(ns_env(package))
-  } else {
-    create_ns_env(path)
+    patch_colon(package)
+
+    methods_env <- ns_s3_methods(package)
+    unregister(package)
+
+    # Save foreign methods after unregistering the package's own
+    # methods. We'll restore the foreign methods but let the package
+    # register its own methods again.
+    old_methods <- as.list(methods_env)
+    old_methods <- Filter(function(x) is_foreign_method(x, package), old_methods)
   }
+
+  create_ns_env(path)
 
   out <- list(env = ns_env(package))
 

--- a/man/load_all.Rd
+++ b/man/load_all.Rd
@@ -24,11 +24,9 @@ is_loading(pkg = NULL)
 \arguments{
 \item{path}{Path to a package, or within a package.}
 
-\item{reset}{clear package environment and reset file cache before loading
-any pieces of the package. This largely equivalent to running
-\code{\link[=unload]{unload()}}, however the old namespaces are not completely removed and no
-\code{.onUnload()} hooks are called. Use \code{reset = FALSE} may be faster for
-large code bases, but is a significantly less accurate approximation.}
+\item{reset}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} This is no longer supported
+because preserving the namespace requires unlocking its environment, which
+is no longer possible in recent versions of R.}
 
 \item{compile}{If \code{TRUE} always recompiles the package; if \code{NA}
 recompiles if needed (as determined by \code{\link[pkgbuild:needs_compile]{pkgbuild::needs_compile()}});
@@ -133,9 +131,6 @@ load_all("./")
 
 # Running again loads changed files
 load_all("./")
-
-# With reset=TRUE, unload and reload the package for a clean start
-load_all("./", TRUE)
 
 # With export_all=FALSE, only objects listed as exports in NAMESPACE
 # are exported

--- a/revdep/failures.md
+++ b/revdep/failures.md
@@ -5,7 +5,7 @@
 * Version: NA
 * GitHub: NA
 * Source code: https://github.com/cran/zellkonverter
-* Number of recursive dependencies: 157
+* Number of recursive dependencies: 153
 
 Run `revdepcheck::cloud_details(, "zellkonverter")` for more info
 

--- a/tests/testthat/test-load-hooks.R
+++ b/tests/testthat/test-load-hooks.R
@@ -26,10 +26,6 @@ test_that("hooks called in correct order", {
   )
 
   reset_events()
-  load_all("testHooks", reset = FALSE)
-  expect_equal(globalenv()$hooks$events, character())
-
-  reset_events()
   unload("testHooks")
   expect_equal(globalenv()$hooks$events,
     c("user_detach", "pkg_detach", "user_unload", "pkg_unload")
@@ -80,13 +76,6 @@ test_that("onLoad and onAttach", {
   expect_equal(the$b, 2)
   expect_equal(the$c, 1)
 
-  # ===================================================================
-  # Loading again without reset won't change a, b, and c in the
-  # namespace env, and also shouldn't trigger onload or onattach. But
-  # the existing namespace values will be copied over to the package
-  # environment
-  load_all("testLoadHooks", reset = FALSE)
-
   # Shouldn't form new environments
   expect_identical(nsenv, ns_env("testLoadHooks"))
   expect_identical(pkgenv, pkg_env("testLoadHooks"))
@@ -96,10 +85,10 @@ test_that("onLoad and onAttach", {
   expect_equal(the$c, 1)
 
   # ===================================================================
-  # With reset=TRUE, there should be new package and namespace
+  # When loading again there should be new package and namespace
   # environments, and the values should be the same as the first
   # load_all.
-  load_all("testLoadHooks", reset = TRUE)
+  load_all("testLoadHooks")
   nsenv2 <- ns_env("testLoadHooks")
   pkgenv2 <- pkg_env("testLoadHooks")
 

--- a/tests/testthat/test-s4-unload.R
+++ b/tests/testthat/test-s4-unload.R
@@ -67,7 +67,7 @@ test_that("loading and reloading s4 classes", {
   })
 
   # Loading again shouldn't result in any errors or warnings
-  expect_no_warning(load_all("testS4union", reset = FALSE) )
+  expect_no_warning(load_all("testS4union") )
 
   unload("testS4union")
   unloadNamespace("stats4")   # This was imported by testS4union


### PR DESCRIPTION
Closes #276.
Progress towards https://github.com/r-lib/rlang/issues/1705.


* The `reset` argument of `load_all()` is now deprecated. Its purpose was to reuse the namespace instead of creating one from scratch. But this code path is not the default, not well tested, and required unlocking the namespace which is no longer possible on recent versions of R.

* We no longer hot-patch `::` in detached namespaces by default. The patched version redirected self-calls via `::` to the detached namespace rather than the currently loaded namespace. This is only needed in very special cases, such as packages containing both native code and standalone files. If the patched `::` is needed, just assign it on load:

    ```r
    on_load(`::` <- base::`::`)
    ```

  This is not documented because AFAIK only rlang needed this behaviour.