### PR TITLE
Optionally skip tests relying on 'bitops'

### DIFF
--- a/tests/testthat/test-namespace.R
+++ b/tests/testthat/test-namespace.R
@@ -1,5 +1,8 @@
 local_load_all_quiet()
 
+# Used by several test packages
+skip_if_not_installed("bitops")
+
 # Is e an ancestor environment of x?
 is_ancestor_env <- function(e, x) {
   if (identical(e, x))


### PR DESCRIPTION
8 failures if {bitops} is missing:

```
══ Failed tests ════════════════════════════════════════════════════════════════
── Error (test-namespace.R:22:3): Loaded namespaces have correct version ───────
── Error (test-namespace.R:31:3): Exported objects are visible from global environment ──
── Error (test-namespace.R:55:3): All objects are loaded into namespace environment ──
── Error (test-namespace.R:64:3): All objects are copied to package environment ──
── Error (test-namespace.R:80:3): Unloading and reloading a package works ──────
── Error (test-namespace.R:103:3): Namespace, imports, and package environments have correct hierarchy ──
── Error (test-namespace.R:121:3): unload() removes package environments from search ──
── Error (test-namespace.R:147:3): Environments have the correct attributes ────
```

Easiest I think to just skip the whole test-namespace.R script if bitops is missing.