### PR TITLE
Enables compilation DB generation for all R include and share paths

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,4 +47,4 @@ Config/testthat/parallel: TRUE
 Config/testthat/start-first: dll
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # pkgload (development version)
 
 * The generator of `compile_commands.json` now checks for existing `R_SHARE_DIR`
-  and `R_INCLUDE_DIR` environment variables (#287, @TimTaylor).
+  and `R_INCLUDE_DIR` environment variables (#287, #296, @TimTaylor and
+  @shikokuchuo).
 
 * The generator of `compile_commands.json` is now more reliable in the presence
   of extra whitespace in `make`'s output (#288, @TimTaylor).

--- a/R/compilation-db.R
+++ b/R/compilation-db.R
@@ -191,8 +191,8 @@ compilers <- function() {
   # These variables are normally set by frontends but just in case
   env <- c(
     "current",
-    R_INCLUDE_DIR = Sys.getenv("R_INCLUDE_DIR", unset = fs::path(R.home(), "include")),
-    R_SHARE_DIR = Sys.getenv("R_SHARE_DIR", unset = fs::path(R.home(), "share"))
+    R_INCLUDE_DIR = R.home("include"),
+    R_SHARE_DIR = R.home("share")
   )
 
   pkgbuild::with_build_tools(


### PR DESCRIPTION
Fixes #296 by using the correct way of returning the `R.home()` paths.

Specifically for `?R.home()`:

> The paths to components often are subdirectories of R_HOME but need not be: "doc", "include" and "share" are not for some Linux binary installations of R.