### PR TITLE
Replace single quotes with escaped double quotes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,8 @@
 * The generator of `compile_commands.json` is now more reliable in the presence
   of extra whitespace in `make`'s output (#288, @TimTaylor).
 
-
+* The generator of `compile_commands.json` now uses escaped double quotes for LinkingTo packages to ensure valid argument strings when parsed on Windows (#305, @tylermorganwall).
+  
 # pkgload 1.4.0
 
 * The `reset` argment of `load_all()` is no longer supported because preserving

--- a/R/compilation-db.R
+++ b/R/compilation-db.R
@@ -268,5 +268,5 @@ linking_to_flags <- function(desc) {
   paths <- vapply(linking_to, function(pkg) system.file("include", package = pkg), "")
   paths <- paths[paths != ""]
 
-  paste(paste0("-I'", paths, "'"), collapse = " ")
+  paste(paste0("-I\"", paths, "\""), collapse = " ")
 }


### PR DESCRIPTION
This fixes the behavior on Windows, which does not always recognize single quotes. This can lead to clangd failing to compile the database correctly.

https://github.com/r-lib/pkgload/issues/305