### PR TITLE
fix: Use relative paths, sort

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pkgload (development version)
 
+* The generator of `compile_commands.json` now works with sources in subdirectories (#308, @krlmlr).
+
 * The generator of `compile_commands.json` now checks for existing `R_SHARE_DIR`
   and `R_INCLUDE_DIR` environment variables (#287, #296, @TimTaylor and
   @shikokuchuo).
@@ -8,7 +10,8 @@
   of extra whitespace in `make`'s output (#288, @TimTaylor).
 
 * The generator of `compile_commands.json` now uses escaped double quotes for LinkingTo packages to ensure valid argument strings when parsed on Windows (#305, @tylermorganwall).
-  
+
+
 # pkgload 1.4.0
 
 * The `reset` argment of `load_all()` is no longer supported because preserving

--- a/R/compilation-db.R
+++ b/R/compilation-db.R
@@ -25,8 +25,8 @@ generate_db <- function(path = ".") {
     return(invisible(NULL))
   }
 
-  files <- build_files(src_path)
-  commands <- build_commands(src_path, package, files, desc)
+  files <- sort(fs::path_rel(build_files(src_path), src_path))
+  commands <- sort(build_commands(src_path, package, files, desc))
   directives <- Map(
     cmd = commands,
     file = files,
@@ -116,7 +116,7 @@ find_source <- function(file) {
     ))
   }
 
-  candidates[[1]]
+  fs::path(dir, candidates[[1]])
 }
 
 build_commands <- function(src_path, package, files, desc) {


### PR DESCRIPTION
Seems required for source files in subdirectories, and/or for parallel `make`. This fixes duckdb for me, along with https://github.com/duckdb/duckdb-r/pull/1012.