### PR TITLE
Fix warning from `load_all()`

### DIFF
--- a/R/compilation-db.R
+++ b/R/compilation-db.R
@@ -199,7 +199,7 @@ compilers <- function() {
     out <- processx::run("make", c(makevars, "print-compilers"), env = env)
   )
 
-  compilers <- strsplit(trimws(out$stdout), "\n")[[1]]
+  compilers <- strsplit(trimws(out$stdout), "\n+")[[1]]
 
   # Remove arguments
   compilers <- strsplit(compilers, " ")


### PR DESCRIPTION
Warning:
```r
> devtools::load_all(".")
ℹ Loading reticulate
Warning message:
subscript out of bounds
```

I tracked it down to the fact that `out$stdout` here has empty lines:
> dput(out$stdout)
"gcc\ng++ -std=gnu++14\ng++\ng++\ng++\n\ngfortran\n\n"

Which downstream become 0-length character vectors that error on `cmp[[1]]`.