### PR TITLE
fix: path bug introduced by #308

### DIFF
--- a/R/compilation-db.R
+++ b/R/compilation-db.R
@@ -69,7 +69,7 @@ build_files <- function(src_path) {
   if (!has_objects) {
     # If the Makevars doesn't define custom objects, just grab all source files
     # in `src`. Same pattern as in `R CMD shlib`.
-    files <- dir(src_path, pattern = "\\.([cfmM]|cc|cpp|f90|f95|mm)$", all.files = TRUE)
+    files <- dir(src_path, pattern = "\\.([cfmM]|cc|cpp|f90|f95|mm)$", all.files = TRUE, full.names = TRUE)
     return(files)
   }
 


### PR DESCRIPTION
AFAICT #308, didn't account for the early return of `build_files()`. I think this is sufficient to fix (locally, for me atleast). @krlmlr - would your issue still be resolved by this small addition?