### PR TITLE
Fix compilation-db issue with extra files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pkgload (development version)
 
+* The generator of `compile_commands.json` now works with packages that compile extra libraries such as ragg.
+
 * The generator of `compile_commands.json` now works with sources in subdirectories (#308, @krlmlr).
 
 * The generator of `compile_commands.json` now checks for existing `R_SHARE_DIR`

--- a/R/compilation-db.R
+++ b/R/compilation-db.R
@@ -69,7 +69,8 @@ has_compilation_db <- function(desc) {
   out
 }
 
-file_pattern <- "\\.([cfmM]|cc|cpp|f90|f95|mm)"
+# Same pattern as in `R CMD shlib`.
+FILE_PATTERN <- "\\.([cfmM]|cc|cpp|f90|f95|mm)"
 
 build_files <- function(src_path) {
   makevars <- makevars_file(src_path)
@@ -78,10 +79,10 @@ build_files <- function(src_path) {
 
   if (!has_objects) {
     # If the Makevars doesn't define custom objects, just grab all source files
-    # in `src`. Same pattern as in `R CMD shlib`.
+    # in `src`.
     files <- dir(
       src_path,
-      pattern = paste0(file_pattern, "$"),
+      pattern = paste0(FILE_PATTERN, "$"),
       all.files = TRUE,
       full.names = TRUE
     )
@@ -113,8 +114,7 @@ build_files <- function(src_path) {
 # Build commands for object files take the input files in `-c` arguments that we
 # extract here
 build_files_from_commands <- function(commands) {
-  file_pattern <- "\\.([cfmM]|cc|cpp|f90|f95|mm)"
-  pattern <- paste0("-c\\s+['\"]?([^\\s]+", file_pattern, ")")
+  pattern <- paste0("-c\\s+['\"]?([^\\s]+", FILE_PATTERN, ")")
 
   files <- regmatches(
     commands,

--- a/R/compilation-db.R
+++ b/R/compilation-db.R
@@ -110,6 +110,8 @@ build_files <- function(src_path) {
   vapply(files, find_source, "")
 }
 
+# Build commands for object files take the input files in `-c` arguments that we
+# extract here
 build_files_from_commands <- function(commands) {
   file_pattern <- "\\.([cfmM]|cc|cpp|f90|f95|mm)"
   pattern <- paste0("-c\\s+['\"]?([^\\s]+", file_pattern, ")")


### PR DESCRIPTION
The compilation-db generation currently fails with ragg because we detect more build commands than we have detected files. That's because ragg's Makevars (a) does not define `OBJECTS`, so we only pick up the top-level source files as `R CMD build` does, and (b) compiles an extra library (see https://github.com/r-lib/ragg/blob/2c09f210bbd4a6df9cc710022195aa63b97eaeb3/src/Makevars.win#L17) whose compilation commands are picked up.

To fix this I reextract object files from the detected commands.

It's possible we could only use that strategy and not have the initial detection of object files, which does seem to work, but since we don't have tests for this part of pkgload and this is a bit tricky as there is a variety of makevars files out there I preferred to keep the existing code in.

cc @thomasp85 