### PR TITLE
fix: FILE_PATTERN needs to match cpp, cc before c and mm before m

### DIFF
--- a/R/compilation-db.R
+++ b/R/compilation-db.R
@@ -70,7 +70,7 @@ has_compilation_db <- function(desc) {
 }
 
 # Same pattern as in `R CMD shlib`.
-FILE_PATTERN <- "\\.([cfmM]|cc|cpp|f90|f95|mm)"
+FILE_PATTERN <- "\\.(cc|cpp|f90|f95|mm|[cfmM])"
 
 build_files <- function(src_path) {
   makevars <- makevars_file(src_path)


### PR DESCRIPTION
When extracting files names from build commands, this file pattern caused `"-c file.cpp"` to extract the name `"file.c"`, because ".c" matches before ".cpp"

