### PR TITLE
Fix PKG_BUILD_EXTRA_FLAGS docs: use 'false' instead of 'FALSE'

### DIFF
--- a/R/load.R
+++ b/R/load.R
@@ -70,8 +70,9 @@
 #' compilation, during which by default some debug compiler flags are
 #' appended. If you would like to produce an optimized build instead, you can
 #' opt out by either using `debug = FALSE`, setting the `pkg.build_extra_flags`
-#' option to `FALSE`, or setting the `PKG_BUILD_EXTRA_FLAGS` environment variable
-#' to `FALSE`. For further details see the Details section in [pkgbuild::compile_dll()].
+#' option to `FALSE`, or setting the `PKG_BUILD_EXTRA_FLAGS` environment
+#' variable to `false`.
+#' For further details see the Details section in [pkgbuild::compile_dll()].
 #'
 #'
 #' @param path Path to a package, or within a package.

--- a/man/load_all.Rd
+++ b/man/load_all.Rd
@@ -134,8 +134,9 @@ be useful for checking for missing exports.
 compilation, during which by default some debug compiler flags are
 appended. If you would like to produce an optimized build instead, you can
 opt out by either using \code{debug = FALSE}, setting the \code{pkg.build_extra_flags}
-option to \code{FALSE}, or setting the \code{PKG_BUILD_EXTRA_FLAGS} environment variable
-to \code{FALSE}. For further details see the Details section in \code{\link[pkgbuild:compile_dll]{pkgbuild::compile_dll()}}.
+option to \code{FALSE}, or setting the \code{PKG_BUILD_EXTRA_FLAGS} environment
+variable to \code{false}.
+For further details see the Details section in \code{\link[pkgbuild:compile_dll]{pkgbuild::compile_dll()}}.
 }
 
 \examples{


### PR DESCRIPTION
The documentation previously suggested using `FALSE` for the `PKG_BUILD_EXTRA_FLAGS` environment variable. However, the actual implementation in [`pkgbuild::compile_dll()`](https://github.com/r-lib/pkgbuild/blob/35af31422aa001226df8bc0018c87f8014e9794e/R/compile-dll.R) requires `false` (lowercase).  

This update corrects the documentation to match the implementation.