### PR TITLE
Be stricter about package name parsing

### DIFF
--- a/R/dev-topic.R
+++ b/R/dev-topic.R
@@ -24,19 +24,18 @@ dev_topic_find <- function(topic, dev_packages = NULL) {
   NULL
 }
 
-dev_topic_parse <- function(topic, dev_packages = NULL) {
+dev_topic_parse <- function(topic, packages = NULL) {
   stopifnot(is_string(topic))
 
-  pieces <- strsplit(topic, ":::?")[[1]]
-  if (length(pieces) == 1) {
-    if (is.null(dev_packages)) {
-      pkgs <- dev_packages()
-    } else {
-      pkgs <- dev_packages
-    }
-  } else {
-    pkgs <- pieces[1]
-    topic <- pieces[2]
+  # Only treat `::`/`:::` as a namespace qualifier when preceded by a valid
+  # package name at the start. Otherwise `::` may appear inside an S7 method
+  # alias like `fn,pkg::Class-method`.
+  m <- regmatches(topic, regexec("^([a-zA-Z][a-zA-Z0-9.]*):::?(.+)$", topic))[[1]]
+  if (length(m) == 3) {
+    pkgs <- m[[2]]
+    topic <- m[[3]]
+  } else  {
+    pkgs <- packages %||% dev_packages()
   }
 
   list(

--- a/tests/testthat/test-help.R
+++ b/tests/testthat/test-help.R
@@ -165,6 +165,23 @@ test_that("can use macros in other packages (#120)", {
   expect_match(html_lines, "foreign macro.*success", all = FALSE)
 })
 
+test_that("dev_topic_parse recognises pkg::topic and pkg:::topic", {
+  parsed <- dev_topic_parse("foo::bar")
+  expect_equal(parsed$topic, "bar")
+  expect_equal(parsed$pkg_names, "foo")
+
+  parsed <- dev_topic_parse("foo:::bar")
+  expect_equal(parsed$topic, "bar")
+  expect_equal(parsed$pkg_names, "foo")
+})
+
+test_that("dev_topic_parse leaves S7 method aliases alone", {
+  topic <- "drop_spec_columns,hyperion.tables::TableSpec-method"
+  parsed <- dev_topic_parse(topic, packages = "mypkg")
+  expect_equal(parsed$topic, topic)
+  expect_equal(parsed$pkg_names, "mypkg")
+})
+
 test_that("httpdPort() is available", {
   skip_on_cran()
   # We're using this unexported function to open help pages in RStudio


### PR DESCRIPTION
Since S7 method aliases qualify the class name with the package name.