### PR TITLE
Skip test assuming translation works

### DIFF
--- a/tests/testthat/test-po.R
+++ b/tests/testthat/test-po.R
@@ -2,6 +2,7 @@ local_load_all_quiet()
 
 test_that("translation domain correctly loaded", {
   skip_if_c_locale()
+  skip_if_not(capabilities("NLS"))
 
   load_all(test_path("testTranslations"))
   defer(unload("testTranslations"))


### PR DESCRIPTION
On builds of R without translations (i.e., configured with` --disable-nls`), this will fail.

I'm not quite sure why {withr} only throws a warning:

https://github.com/r-lib/withr/blob/22e392c9cc13efaa9ba042bb193991f78316edb1/R/language.R#L39-L41